### PR TITLE
add Instant.wrapping_duration_since

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,11 +147,22 @@ impl Instant {
         Instant::now() - *self
     }
 
+    /// Returns the amount of time elapsed since this instant was created.
+    pub fn wrapping_elapsed(&self) -> Duration {
+        Duration(Instant::now().0.wrapping_sub(self.0) as u32)
+    }
+
     /// Returns the amount of time elapsed from another instant to this one.
+    /// panics when earlier is later than self
     pub fn duration_since(&self, earlier: Instant) -> Duration {
         let diff = self.0 - earlier.0;
         assert!(diff >= 0, "second instant is later than self");
         Duration(diff as u32)
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one.
+    pub fn wrapping_duration_since(&self, earlier: Instant) -> Duration {
+        Duration(self.0.wrapping_sub(earlier.0) as u32)
     }
 }
 


### PR DESCRIPTION
This adds Instant.wrapping_duration_since for the case that some result is desired but the overhead of managing overflows is too big. Especially when handling it seems as complicated as adding 64bit support to Instant.

I also added a wrapping_elapsed but one could argue that elapsed has a bug and should be replaced with the wrapping version.

```rust
// pseudocodeish
init() {
  block((u32::max_value()/2).cycles());
  let t1 = Instant::new(); // t1 = i32::min_value() + 1
  block((u32::max_value()/2).cycles() + 10);
  t1.elapsed() // Instant::new() = t2 = 10
  // t1 - t2 = overflow = panic in debug build
}
```

While writing this i had an idea how to implement a 64bit timer.
```rust
struct BigInstant(u64);
static mut last_tick: Instant = Insant::new();
static mut total_ticks: BigInstant = BigInstant::new()
/// this must be executed before Instant overflows
fn BigInstant::tick() {
  let now = Instant::new();
  total_ticks += now.wrapping_sub(last_tick);
  last_tick = now;
}
fn BigInstant::now() -> BigInstant {
  total_ticks + Instant::new().wrapping_sub(last_tick)
}
```
while this snippet ignored atomicity/locking the general idea should be workable and avoids the need for a max priority interrupt to increment the high bits on overflow.
