### PR TITLE
Increase MSRV to 1.41.0, as this was when profile-overrides landed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           - x86_64-unknown-linux-gnu
         toolchain:
           - stable
-          - 1.36.0
+          - 1.41.0
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -56,10 +56,6 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}
           override: true
-
-      - name: Disable optimisation profiles
-        if: matrix.toolchain == '1.36.0'
-        run: sed -i '/^\[profile.*build-override]$/,/^$/{/^#/!{/^$/!d}}' Cargo.toml
 
       - name: cargo check
         uses: actions-rs/cargo@v1
@@ -261,7 +257,7 @@ jobs:
           - x86_64-unknown-linux-gnu
         toolchain:
           - stable
-          - 1.36.0
+          - 1.41.0
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -271,10 +267,6 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}
           override: true
-
-      - name: Disable optimisation profiles
-        if: matrix.toolchain == '1.36.0'
-        run: sed -i '/^\[profile.*build-override]$/,/^$/{/^#/!{/^$/!d}}' Cargo.toml
 
       - name: cargo check
         uses: actions-rs/cargo@v1
@@ -293,12 +285,9 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.36.0
+          toolchain: 1.41.0
           target: thumbv7m-none-eabi
           override: true
-
-      - name: Disable optimisation profiles
-        run: sed -i '/^\[profile.*build-override]$/,/^$/{/^#/!{/^$/!d}}' Cargo.toml
 
       - uses: actions-rs/cargo@v1
         with:
@@ -316,12 +305,9 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.36.0
+          toolchain: 1.41.0
           target: thumbv6m-none-eabi
           override: true
-
-      - name: Disable optimisation profiles
-        run: sed -i '/^\[profile.*build-override]$/,/^$/{/^#/!{/^$/!d}}' Cargo.toml
 
       - uses: actions-rs/cargo@v1
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
 
       # MSRV
     - env: TARGET=thumbv7m-none-eabi
-      rust: 1.36.0
+      rust: 1.41.0
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv6m-none-eabi

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Formerly known as Real-Time For the Masses.
 
 ## Requirements
 
-- Rust 1.36.0+
+- Rust 1.41.0+
 
 - Applications must be written using the 2018 edition.
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -50,7 +50,7 @@ main() {
         fi
 
         if [ $TRAVIS_RUST_VERSION = nightly ]; then
-            # Tests where required MSRV > 1.36
+            # Tests where required MSRV > 1.41
             #local exs=(
             #)
             #for ex in ${exs[@]}; do

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! This crate is guaranteed to compile on stable Rust 1.36 (2018 edition) and up. It *might*
+//! This crate is guaranteed to compile on stable Rust 1.41 (2018 edition) and up. It *might*
 //! compile on older versions but that may change in any new patch release.
 //!
 //! # Semantic Versioning


### PR DESCRIPTION
profile-overrides landed in 1.41 https://github.com/rust-lang/cargo/pull/7591/

I appreciate that the intention may be to maintain support for earlier rust versions if the profile-overrides keys are deleted from the README. But if the crate throws an error when compiled with its MSRV compiler, that in my opinion/understanding defeats the purpose of the MSRV.