### PR TITLE
Examples: Clarify extern section

### DIFF
--- a/examples/baseline.rs
+++ b/examples/baseline.rs
@@ -45,7 +45,10 @@ const APP: () = {
         cx.spawn.foo().unwrap();
     }
 
+    // RTIC requires that unused interrupts are declared in an extern block when
+    // using software tasks; these free interrupts will be used to dispatch the
+    // software tasks.
     extern "C" {
-        fn UART1();
+        fn SSI0();
     }
 };

--- a/examples/capacity.rs
+++ b/examples/capacity.rs
@@ -38,8 +38,10 @@ const APP: () = {
         debug::exit(debug::EXIT_SUCCESS);
     }
 
-    // Interrupt handlers used to dispatch software tasks
+    // RTIC requires that unused interrupts are declared in an extern block when
+    // using software tasks; these free interrupts will be used to dispatch the
+    // software tasks.
     extern "C" {
-        fn UART1();
+        fn SSI0();
     }
 };

--- a/examples/cfg.rs
+++ b/examples/cfg.rs
@@ -57,8 +57,11 @@ const APP: () = {
         .ok();
     }
 
+    // RTIC requires that unused interrupts are declared in an extern block when
+    // using software tasks; these free interrupts will be used to dispatch the
+    // software tasks.
     extern "C" {
-        fn UART0();
-        fn UART1();
+        fn SSI0();
+        fn QEI0();
     }
 };

--- a/examples/message.rs
+++ b/examples/message.rs
@@ -43,7 +43,10 @@ const APP: () = {
         c.spawn.foo().unwrap();
     }
 
+    // RTIC requires that unused interrupts are declared in an extern block when
+    // using software tasks; these free interrupts will be used to dispatch the
+    // software tasks.
     extern "C" {
-        fn UART0();
+        fn SSI0();
     }
 };

--- a/examples/not-send.rs
+++ b/examples/not-send.rs
@@ -53,8 +53,11 @@ const APP: () = {
         debug::exit(debug::EXIT_SUCCESS);
     }
 
+    // RTIC requires that unused interrupts are declared in an extern block when
+    // using software tasks; these free interrupts will be used to dispatch the
+    // software tasks.
     extern "C" {
-        fn UART0();
-        fn UART1();
+        fn SSI0();
+        fn QEI0();
     }
 };

--- a/examples/not-sync.rs
+++ b/examples/not-sync.rs
@@ -36,7 +36,10 @@ const APP: () = {
         let _: &NotSync = c.resources.shared;
     }
 
+    // RTIC requires that unused interrupts are declared in an extern block when
+    // using software tasks; these free interrupts will be used to dispatch the
+    // software tasks.
     extern "C" {
-        fn UART0();
+        fn SSI0();
     }
 };

--- a/examples/periodic.rs
+++ b/examples/periodic.rs
@@ -29,7 +29,10 @@ const APP: () = {
         cx.schedule.foo(cx.scheduled + PERIOD.cycles()).unwrap();
     }
 
+    // RTIC requires that unused interrupts are declared in an extern block when
+    // using software tasks; these free interrupts will be used to dispatch the
+    // software tasks.
     extern "C" {
-        fn UART0();
+        fn SSI0();
     }
 };

--- a/examples/pool.rs
+++ b/examples/pool.rs
@@ -59,8 +59,11 @@ const APP: () = {
         // drop(x);
     }
 
+    // RTIC requires that unused interrupts are declared in an extern block when
+    // using software tasks; these free interrupts will be used to dispatch the
+    // software tasks.
     extern "C" {
-        fn UART0();
-        fn UART1();
+        fn SSI0();
+        fn QEI0();
     }
 };

--- a/examples/schedule.rs
+++ b/examples/schedule.rs
@@ -44,7 +44,10 @@ const APP: () = {
         hprintln!("bar  @ {:?}", Instant::now()).unwrap();
     }
 
+    // RTIC requires that unused interrupts are declared in an extern block when
+    // using software tasks; these free interrupts will be used to dispatch the
+    // software tasks.
     extern "C" {
-        fn UART0();
+        fn SSI0();
     }
 };

--- a/examples/t-cfg.rs
+++ b/examples/t-cfg.rs
@@ -43,8 +43,11 @@ const APP: () = {
     #[task]
     fn quux(_: quux::Context) {}
 
+    // RTIC requires that unused interrupts are declared in an extern block when
+    // using software tasks; these free interrupts will be used to dispatch the
+    // software tasks.
     extern "C" {
-        fn UART0();
-        fn UART1();
+        fn SSI0();
+        fn QEI0();
     }
 };

--- a/examples/t-schedule.rs
+++ b/examples/t-schedule.rs
@@ -53,7 +53,10 @@ const APP: () = {
     #[task]
     fn baz(_: baz::Context, _x: u32, _y: u32) {}
 
+    // RTIC requires that unused interrupts are declared in an extern block when
+    // using software tasks; these free interrupts will be used to dispatch the
+    // software tasks.
     extern "C" {
-        fn UART1();
+        fn SSI0();
     }
 };

--- a/examples/t-spawn.rs
+++ b/examples/t-spawn.rs
@@ -52,7 +52,10 @@ const APP: () = {
     #[task]
     fn baz(_: baz::Context, _x: u32, _y: u32) {}
 
+    // RTIC requires that unused interrupts are declared in an extern block when
+    // using software tasks; these free interrupts will be used to dispatch the
+    // software tasks.
     extern "C" {
-        fn UART1();
+        fn SSI0();
     }
 };

--- a/examples/t-stask-main.rs
+++ b/examples/t-stask-main.rs
@@ -18,7 +18,10 @@ const APP: () = {
         debug::exit(debug::EXIT_SUCCESS);
     }
 
+    // RTIC requires that unused interrupts are declared in an extern block when
+    // using software tasks; these free interrupts will be used to dispatch the
+    // software tasks.
     extern "C" {
-        fn UART0();
+        fn SSI0();
     }
 };

--- a/examples/task.rs
+++ b/examples/task.rs
@@ -45,9 +45,11 @@ const APP: () = {
         hprintln!("baz").unwrap();
     }
 
-    // Interrupt handlers used to dispatch software tasks
+    // RTIC requires that unused interrupts are declared in an extern block when
+    // using software tasks; these free interrupts will be used to dispatch the
+    // software tasks.
     extern "C" {
-        fn UART0();
-        fn UART1();
+        fn SSI0();
+        fn QEI0();
     }
 };

--- a/examples/types.rs
+++ b/examples/types.rs
@@ -52,7 +52,10 @@ const APP: () = {
         let _: foo::Spawn = cx.spawn;
     }
 
+    // RTIC requires that unused interrupts are declared in an extern block when
+    // using software tasks; these free interrupts will be used to dispatch the
+    // software tasks.
     extern "C" {
-        fn UART1();
+        fn SSI0();
     }
 };


### PR DESCRIPTION
Some beginners are confused about the "extern" section, so I added an explanation comment to all examples.

![image](https://user-images.githubusercontent.com/105168/85903840-9ad2a780-b807-11ea-943d-3f37b814c23f.png)

Furthermore, using the UARTx interrupts when UART is actually being used in the same example may be confusing, so I changed them all to SSI0/QEI0.