### PR TITLE
Enable caching for Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,15 +152,6 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-qemu
 
-      - name: Cache arm-none-eabi-gcc
-        id: cache-arm-none-eabi-gcc
-        uses: actions/cache@v2
-        with:
-          path: arm-none-eabi-gcc
-          key: ${{ runner.OS }}-gcc
-          restore-keys: |
-            ${{ runner.OS }}-gcc
-
       - name: Install Rust ${{ matrix.toolchain }} with target (${{ matrix.target }})
         uses: actions-rs/toolchain@v1
         with:
@@ -200,19 +191,6 @@ jobs:
           GITHUB_WORKSPACE: ${{ github.workspace }}
         run: echo "::add-path::${GITHUB_WORKSPACE}/qemu"
 
-      #- name: Setup arm-none-eabi-gcc
-        #if: steps.cache-arm-none-eabi-gcc.outputs.cache-hit != 'true'
-        #uses: fiam/arm-none-eabi-gcc@v1
-        #with:
-          #directory: 'arm-none-eabi-gcc' # Place it locally so it is possible to cache
-          #release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
-
-      #- name: Setup add arm-none-eabi-gcc to PATH
-        #if: steps.cache-arm-none-eabi-gcc.outputs.cache-hit == 'true'
-        #env:
-          #GITHUB_WORKSPACE: ${{ github.workspace }}
-        #run: echo "::add-path::${GITHUB_WORKSPACE}/arm-none-eabi-gcc/bin"
-
       - name: Run-pass tests
         run: |
           # Print the path
@@ -245,7 +223,6 @@ jobs:
               else
                   cargo $COMMAND $CARGO_FLAGS
               fi
-              #arm-none-eabi-objcopy -O ihex target/${{ matrix.target }}/$BUILD_MODE/examples/$EXAMPLE ci/builds/${EXAMPLE}_${FEATURES_STR}${BUILD_MODE}_${BUILD_NUM}.hex
               cargo objcopy $CARGO_FLAGS  -- -O ihex ci/builds/${EXAMPLE}_${FEATURES_STR}${BUILD_MODE}_${BUILD_NUM}.hex
           }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   # Run cargo fmt --check, includes macros/
   style:
     name: style
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -36,7 +36,7 @@ jobs:
   # Compilation check
   check:
     name: check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         target:
@@ -101,7 +101,7 @@ jobs:
   # Verify all examples
   checkexamples:
     name: checkexamples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         target:
@@ -333,7 +333,7 @@ jobs:
   # Check the correctness of macros/ crate
   checkmacros:
     name: checkmacros
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         target:
@@ -396,7 +396,7 @@ jobs:
   # Run test suite for thumbv7m
   testv7:
     name: testv7
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -448,7 +448,7 @@ jobs:
   # Run test suite for thumbv6m
   testv6:
     name: testv6
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -500,7 +500,7 @@ jobs:
   # Verify all multicore examples
   checkmulticore:
     name: checkmulticore
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         target:
@@ -551,7 +551,7 @@ jobs:
   # Build documentation, check links
   docs:
     name: docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout
@@ -624,7 +624,7 @@ jobs:
   # Build the books
   mdbook:
     name: mdbook
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -669,7 +669,7 @@ jobs:
   # Only runs when pushing to master branch
   deploy:
     name: deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - style
       - check
@@ -784,7 +784,7 @@ jobs:
       - checkmulticore
       - docs
       - mdbook
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Mark the job as a success
         run: exit 0
@@ -801,7 +801,7 @@ jobs:
       - checkmulticore
       - docs
       - mdbook
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Mark the job as a failure
         run: exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,15 +143,6 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-rust-${{ env.rustc_hash }}
 
-      - name: Cache QEMU binary
-        id: cache-qemu-binary
-        uses: actions/cache@v2
-        with:
-          path: qemu
-          key: ${{ runner.OS }}-qemu
-          restore-keys: |
-            ${{ runner.OS }}-qemu
-
       - name: Install Rust ${{ matrix.toolchain }} with target (${{ matrix.target }})
         uses: actions-rs/toolchain@v1
         with:
@@ -181,16 +172,9 @@ jobs:
           use-tool-cache: true
 
       - name: Install QEMU
-        if: steps.cache-qemu-binary.outputs.cache-hit != 'true'
         run: |
-          mkdir -p qemu
-          curl -C - -L https://github.com/japaric/qemu-bin/raw/master/14.04/qemu-system-arm-2.12.0 > qemu/qemu-system-arm
-          chmod +x qemu/qemu-system-arm
-
-      - name: Setup add QEMU to PATH
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-        run: echo "::add-path::${GITHUB_WORKSPACE}/qemu"
+          sudo apt update
+          sudo apt install -y qemu-system-arm
 
       - name: Run-pass tests
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            - ~/.cargo/bin/
+            - ~/.cargo/registry/index/
+            - ~/.cargo/registry/cache/
+            - ~/.cargo/git/db/
+          key: ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.OS }}-cargo-
+
+      - name: Cache build output dependencies
+        uses: actions/cache@v2
+        with:
+          path: target
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.OS }}-build-
+
+      - name: Cache Rust toolchain
+        uses: actions/cache@v2
+        with:
+          path: /usr/share/rust/
+          key: ${{ runner.OS }}-rust-${{ env.rustc_hash }}
+          restore-keys: |
+            ${{ runner.OS }}-rust-${{ env.rustc_hash }}
+
       - name: Install Rust ${{ matrix.toolchain }} with target (${{ matrix.target }})
         uses: actions-rs/toolchain@v1
         with:
@@ -83,6 +113,54 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            - ~/.cargo/bin/
+            - ~/.cargo/registry/index/
+            - ~/.cargo/registry/cache/
+            - ~/.cargo/git/db/
+          key: ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.OS }}-cargo-
+
+      - name: Cache build output dependencies
+        uses: actions/cache@v2
+        with:
+          path: target
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.OS }}-build-
+
+      - name: Cache Rust toolchain
+        uses: actions/cache@v2
+        with:
+          path: /usr/share/rust/
+          key: ${{ runner.OS }}-rust-${{ env.rustc_hash }}
+          restore-keys: |
+            ${{ runner.OS }}-rust-${{ env.rustc_hash }}
+
+      - name: Cache QEMU binary
+        id: cache-qemu-binary
+        uses: actions/cache@v2
+        with:
+          path: qemu
+          key: ${{ runner.OS }}-qemu
+          restore-keys: |
+            ${{ runner.OS }}-qemu
+
+      - name: Cache arm-none-eabi-gcc
+        id: cache-arm-none-eabi-gcc
+        uses: actions/cache@v2
+        with:
+          path: arm-none-eabi-gcc
+          key: ${{ runner.OS }}-gcc
+          restore-keys: |
+            ${{ runner.OS }}-gcc
+
       - name: Install Rust ${{ matrix.toolchain }} with target (${{ matrix.target }})
         uses: actions-rs/toolchain@v1
         with:
@@ -103,21 +181,35 @@ jobs:
           args: -p homogeneous --examples --target=${{ matrix.target }}
 
       - name: Install QEMU
+        if: steps.cache-qemu-binary.outputs.cache-hit != 'true'
         run: |
-          mkdir qemu
-          curl -L https://github.com/japaric/qemu-bin/raw/master/14.04/qemu-system-arm-2.12.0 > qemu/qemu-system-arm
+          mkdir -p qemu
+          curl -C - -L https://github.com/japaric/qemu-bin/raw/master/14.04/qemu-system-arm-2.12.0 > qemu/qemu-system-arm
           chmod +x qemu/qemu-system-arm
 
+      - name: Setup add QEMU to PATH
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+        run: echo "::add-path::${GITHUB_WORKSPACE}/qemu"
+
       - name: Setup arm-none-eabi-gcc
+        if: steps.cache-arm-none-eabi-gcc.outputs.cache-hit != 'true'
         uses: fiam/arm-none-eabi-gcc@v1
         with:
+          directory: 'arm-none-eabi-gcc' # Place it locally so it is possible to cache
           release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
+
+      - name: Setup add arm-none-eabi-gcc to PATH
+        if: steps.cache-arm-none-eabi-gcc.outputs.cache-hit == 'true'
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+        run: echo "::add-path::${GITHUB_WORKSPACE}/arm-none-eabi-gcc/bin"
 
       - name: Run-pass tests
         run: |
-          # Add QEMU to the path
+          # Print the path
           echo $PATH
-          PATH=$(pwd)/qemu:$PATH
+          #PATH=$(pwd)/qemu:$PATH
           arm_example() {
               local COMMAND=$1
               local EXAMPLE=$2
@@ -267,6 +359,37 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            - ~/.cargo/bin/
+            - ~/.cargo/registry/index/
+            - ~/.cargo/registry/cache/
+            - ~/.cargo/git/db/
+          key: ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.OS }}-cargo-
+
+      - name: Cache build output dependencies
+        uses: actions/cache@v2
+        with:
+          path: target
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.OS }}-build-
+
+      - name: Cache Rust toolchain
+        uses: actions/cache@v2
+        with:
+          path: /usr/share/rust/
+          key: ${{ runner.OS }}-rust-${{ env.rustc_hash }}
+          restore-keys: |
+            ${{ runner.OS }}-rust-${{ env.rustc_hash }}
+
       - name: Install Rust ${{ matrix.toolchain }} with target (${{ matrix.target }})
         uses: actions-rs/toolchain@v1
         with:
@@ -292,6 +415,35 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            - ~/.cargo/bin/
+            - ~/.cargo/registry/index/
+            - ~/.cargo/registry/cache/
+            - ~/.cargo/git/db/
+          key: ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-cargo-
+
+      - name: Cache build output dependencies
+        uses: actions/cache@v2
+        with:
+          path: target
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-
+
+      - name: Cache Rust toolchain
+        uses: actions/cache@v2
+        with:
+          path: /usr/share/rust/
+          key: ${{ runner.OS }}-rust-${{ env.rustc_hash }}
+          restore-keys: |
+            ${{ runner.OS }}-rust-${{ env.rustc_hash }}
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -315,6 +467,35 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            - ~/.cargo/bin/
+            - ~/.cargo/registry/index/
+            - ~/.cargo/registry/cache/
+            - ~/.cargo/git/db/
+          key: ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-cargo-
+
+      - name: Cache build output dependencies
+        uses: actions/cache@v2
+        with:
+          path: target
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-
+
+      - name: Cache Rust toolchain
+        uses: actions/cache@v2
+        with:
+          path: /usr/share/rust/
+          key: ${{ runner.OS }}-rust-${{ env.rustc_hash }}
+          restore-keys: |
+            ${{ runner.OS }}-rust-${{ env.rustc_hash }}
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -390,6 +571,42 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            - ~/.cargo/bin/
+            - ~/.cargo/registry/index/
+            - ~/.cargo/registry/cache/
+            - ~/.cargo/git/db/
+          key: ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-cargo-
+
+      - name: Cache build output dependencies
+        uses: actions/cache@v2
+        with:
+          path: target
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-
+
+      - name: Cache Rust toolchain
+        uses: actions/cache@v2
+        with:
+          path: /usr/share/rust/
+          key: ${{ runner.OS }}-rust-${{ env.rustc_hash }}
+          restore-keys: |
+            ${{ runner.OS }}-rust-${{ env.rustc_hash }}
+
+      - name: Cache pip installed linkchecker
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
       - name: Set up Python 3.x
         uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,6 +172,7 @@ jobs:
           command: check
           args: -p homogeneous --examples --target=${{ matrix.target }}
 
+      # Use precompiled binutils
       - name: cargo install cargo-binutils
         uses: actions-rs/install@v0.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,7 +209,7 @@ jobs:
         run: |
           # Print the path
           echo $PATH
-          #PATH=$(pwd)/qemu:$PATH
+
           arm_example() {
               local COMMAND=$1
               local EXAMPLE=$2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,6 +167,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}
           override: true
+          components: llvm-tools-preview
       - uses: actions-rs/cargo@v1
         with:
           use-cross: false
@@ -180,6 +181,13 @@ jobs:
           command: check
           args: -p homogeneous --examples --target=${{ matrix.target }}
 
+      - name: cargo install cargo-binutils
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-binutils
+          version: latest
+          use-tool-cache: true
+
       - name: Install QEMU
         if: steps.cache-qemu-binary.outputs.cache-hit != 'true'
         run: |
@@ -192,18 +200,18 @@ jobs:
           GITHUB_WORKSPACE: ${{ github.workspace }}
         run: echo "::add-path::${GITHUB_WORKSPACE}/qemu"
 
-      - name: Setup arm-none-eabi-gcc
-        if: steps.cache-arm-none-eabi-gcc.outputs.cache-hit != 'true'
-        uses: fiam/arm-none-eabi-gcc@v1
-        with:
-          directory: 'arm-none-eabi-gcc' # Place it locally so it is possible to cache
-          release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
+      #- name: Setup arm-none-eabi-gcc
+        #if: steps.cache-arm-none-eabi-gcc.outputs.cache-hit != 'true'
+        #uses: fiam/arm-none-eabi-gcc@v1
+        #with:
+          #directory: 'arm-none-eabi-gcc' # Place it locally so it is possible to cache
+          #release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
 
-      - name: Setup add arm-none-eabi-gcc to PATH
-        if: steps.cache-arm-none-eabi-gcc.outputs.cache-hit == 'true'
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-        run: echo "::add-path::${GITHUB_WORKSPACE}/arm-none-eabi-gcc/bin"
+      #- name: Setup add arm-none-eabi-gcc to PATH
+        #if: steps.cache-arm-none-eabi-gcc.outputs.cache-hit == 'true'
+        #env:
+          #GITHUB_WORKSPACE: ${{ github.workspace }}
+        #run: echo "::add-path::${GITHUB_WORKSPACE}/arm-none-eabi-gcc/bin"
 
       - name: Run-pass tests
         run: |
@@ -237,7 +245,8 @@ jobs:
               else
                   cargo $COMMAND $CARGO_FLAGS
               fi
-              arm-none-eabi-objcopy -O ihex target/${{ matrix.target }}/$BUILD_MODE/examples/$EXAMPLE ci/builds/${EXAMPLE}_${FEATURES_STR}${BUILD_MODE}_${BUILD_NUM}.hex
+              #arm-none-eabi-objcopy -O ihex target/${{ matrix.target }}/$BUILD_MODE/examples/$EXAMPLE ci/builds/${EXAMPLE}_${FEATURES_STR}${BUILD_MODE}_${BUILD_NUM}.hex
+              cargo objcopy $CARGO_FLAGS  -- -O ihex ci/builds/${EXAMPLE}_${FEATURES_STR}${BUILD_MODE}_${BUILD_NUM}.hex
           }
 
           mkdir -p ci/builds
@@ -282,15 +291,13 @@ jobs:
                           $td/pool.run
                   grep 'foo(0x2' $td/pool.run
                   grep 'bar(0x2' $td/pool.run
-                  arm-none-eabi-objcopy -O ihex target/${{ matrix.target }}/debug/examples/$ex \
-                                          ci/builds/${ex}___v7_debug_1.hex
+                  cargo objcopy --example $ex --target ${{ matrix.target }} --features __v7 -- -O ihex ci/builds/${ex}___v7_debug_1.hex
 
                   cargo run --example $ex --target ${{ matrix.target }} --features __v7 --release >\
                           $td/pool.run
                   grep 'foo(0x2' $td/pool.run
                   grep 'bar(0x2' $td/pool.run
-                  arm-none-eabi-objcopy -O ihex target/${{ matrix.target }}/release/examples/$ex \
-                                          ci/builds/${ex}___v7_release_1.hex
+                  cargo objcopy --example $ex --target ${{ matrix.target }} --features __v7 --release -- -O ihex ci/builds/${ex}___v7_release_1.hex
 
                   rm -rf $td
 


### PR DESCRIPTION
Using [GHA caching](https://docs.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows) to store key parts of the testing environment.

One example is downloading `arm-none-eabi-gcc` (which takes roughly 1 minute) for each checkexamples.

The rustup setup is roughly 200MB and restores nicely.

Rust examples can be found [here](https://github.com/actions/cache/blob/master/examples.md#rust---cargo)

**Something to discuss:**

Several notable projects remove some problematic files in order to keep cache size reasonable

[rust-analyzer](https://github.com/rust-analyzer/rust-analyzer/blob/9a7db8fa009c612168ef16f6ed72315b5406ed09/.travis.yml#L2-L4)

[cargo duscussion](https://github.com/rust-lang/cargo/issues/5885)

[tantivity-search](https://github.com/tantivy-search/tantivy/pull/531/files)

[clap-rs](https://github.com/clap-rs/clap/pull/1658/files#diff-354f30a63fb0907d4ad57269548329e3R5-R16)
