### PR TITLE
Updated URL for example 'init.rs' file

### DIFF
--- a/book/en/src/by-example/new.md
+++ b/book/en/src/by-example/new.md
@@ -48,7 +48,7 @@ Here I'll use the `init` example from the `cortex-m-rtic` crate.
 
 ``` console
 $ curl \
-    -L https://github.com/rtic-rs/cortex-m-rtic/raw/v0.5.0/examples/init.rs \
+    -L https://github.com/rtic-rs/cortex-m-rtic/raw/v0.5.3/examples/init.rs \
     > src/main.rs
 ```
 


### PR DESCRIPTION
(the file at tag '0.5.0' still uses `rtfm`, rather than `rtic` from tag '0.5.3' or later)