### PR TITLE
Rust toolchain cache breaking on version change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,15 +72,6 @@ jobs:
             ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.OS }}-build-
 
-      # Causes failure when new rustc
-      - name: Cache Rust toolchain
-        uses: actions/cache@v2
-        with:
-          path: /usr/share/rust/
-          key: ${{ runner.OS }}-rust-${{ env.rustc_hash }}
-          restore-keys: |
-            ${{ runner.OS }}-rust-${{ env.rustc_hash }}
-
       - name: Install Rust ${{ matrix.toolchain }} with target (${{ matrix.target }})
         uses: actions-rs/toolchain@v1
         with:
@@ -135,15 +126,6 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.OS }}-build-
-
-      # Causes failure when new rustc
-      - name: Cache Rust toolchain
-        uses: actions/cache@v2
-        with:
-          path: /usr/share/rust/
-          key: ${{ runner.OS }}-rust-${{ env.rustc_hash }}
-          restore-keys: |
-            ${{ runner.OS }}-rust-${{ env.rustc_hash }}
 
       - name: Install Rust ${{ matrix.toolchain }} with target (${{ matrix.target }})
         uses: actions-rs/toolchain@v1
@@ -346,15 +328,6 @@ jobs:
             ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.OS }}-build-
 
-      # Causes failure when new rustc
-      - name: Cache Rust toolchain
-        uses: actions/cache@v2
-        with:
-          path: /usr/share/rust/
-          key: ${{ runner.OS }}-rust-${{ env.rustc_hash }}
-          restore-keys: |
-            ${{ runner.OS }}-rust-${{ env.rustc_hash }}
-
       - name: Install Rust ${{ matrix.toolchain }} with target (${{ matrix.target }})
         uses: actions-rs/toolchain@v1
         with:
@@ -401,15 +374,6 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-build-
 
-      # Causes failure when new rustc
-      - name: Cache Rust toolchain
-        uses: actions/cache@v2
-        with:
-          path: /usr/share/rust/
-          key: ${{ runner.OS }}-rust-${{ env.rustc_hash }}
-          restore-keys: |
-            ${{ runner.OS }}-rust-${{ env.rustc_hash }}
-
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -453,15 +417,6 @@ jobs:
           key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.OS }}-build-
-
-      # Causes failure when new rustc
-      - name: Cache Rust toolchain
-        uses: actions/cache@v2
-        with:
-          path: /usr/share/rust/
-          key: ${{ runner.OS }}-rust-${{ env.rustc_hash }}
-          restore-keys: |
-            ${{ runner.OS }}-rust-${{ env.rustc_hash }}
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -507,15 +462,6 @@ jobs:
           key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.OS }}-build-
-
-      # Causes failure when new rustc
-      - name: Cache Rust toolchain
-        uses: actions/cache@v2
-        with:
-          path: /usr/share/rust/
-          key: ${{ runner.OS }}-rust-${{ env.rustc_hash }}
-          restore-keys: |
-            ${{ runner.OS }}-rust-${{ env.rustc_hash }}
 
       - name: Cache pip installed linkchecker
         uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
             ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.OS }}-build-
 
+      # Causes failure when new rustc
       - name: Cache Rust toolchain
         uses: actions/cache@v2
         with:
@@ -135,6 +136,7 @@ jobs:
             ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.OS }}-build-
 
+      # Causes failure when new rustc
       - name: Cache Rust toolchain
         uses: actions/cache@v2
         with:
@@ -344,6 +346,7 @@ jobs:
             ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.OS }}-build-
 
+      # Causes failure when new rustc
       - name: Cache Rust toolchain
         uses: actions/cache@v2
         with:
@@ -398,6 +401,7 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-build-
 
+      # Causes failure when new rustc
       - name: Cache Rust toolchain
         uses: actions/cache@v2
         with:
@@ -450,6 +454,7 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-build-
 
+      # Causes failure when new rustc
       - name: Cache Rust toolchain
         uses: actions/cache@v2
         with:
@@ -503,6 +508,7 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-build-
 
+      # Causes failure when new rustc
       - name: Cache Rust toolchain
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
There seems to be issues when Rust 1.45 is upgraded to 1.46.

```
[command]/usr/share/rust/.cargo/bin/rustup show
Default host: x86_64-unknown-linux-gnu
rustup home:  /home/runner/.rustup

stable-x86_64-unknown-linux-gnu (directory override for '/home/runner/work/cortex-m-rtic/cortex-m-rtic')
rustc 1.45.2 (d3fb005a3 2020-07-31)
[command]/usr/share/rust/.cargo/bin/rustup toolchain install stable
info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'
info: latest update on 2020-08-27, rust version 1.46.0 (04488afe3 2020-08-24)
info: downloading component 'clippy'
info: downloading component 'rustfmt'
info: downloading component 'cargo'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: removing previous version of component 'clippy'
info: removing previous version of component 'rustfmt'
info: removing previous version of component 'cargo'
info: removing previous version of component 'rust-std'
info: removing previous version of component 'rustc'
info: installing component 'clippy'
info: Defaulting to 500.0 MiB unpack ram
info: installing component 'rustfmt'
info: installing component 'cargo'
info: installing component 'rust-std'
info: rolling back changes
error: could not rename component file from '/home/runner/.rustup/tmp/5ymt177yixkhb4fl_dir/bk' to '/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/share'
error: could not rename component file from '/home/runner/.rustup/tmp/yvk581uxohbpg7yg_dir/bk' to '/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/share/doc'
error: could not rename component file from '/home/runner/.rustup/tmp/mth68dj6icrr8wix_dir/bk' to '/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/share/man'
error: could not rename component file from '/home/runner/.rustup/tmp/ve_xiaam6y08_0nm_dir/bk' to '/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/etc'
error: could not rename component file from '/home/runner/.rustup/tmp/p658oanwd5shnzba_dir/bk' to '/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/share/zsh'
error: failed to install component: 'rust-std-x86_64-unknown-linux-gnu', detected conflict: '"lib/rustlib/x86_64-unknown-linux-gnu/lib/libunwind-0bb9b63424f4fc5d.rlib"'
##[error]The process '/usr/share/rust/.cargo/bin/rustup' failed with exit code 1

```
Note that `/home/runner/.rustup` links to `/usr/share/rust/.rustup`

Disabling the cache for rust toolchain seems to not cause this issue