### PR TITLE
Detect if the rt flag is defined in the PAC/HAL

### DIFF
--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -144,7 +144,7 @@ pub fn app(app: &App, analysis: &Analysis, extra: &Extra) -> TokenStream2 {
         /// Implementation details
         mod #name {
             /// Always include the device crate which contains the vector table
-            use #device as _;
+            use #device as you_must_enable_the_rt_feature_for_the_pac_in_your_cargo_toml;
             #(#imports)*
             #(#user_imports)*
 

--- a/macros/src/codegen/pre_init.rs
+++ b/macros/src/codegen/pre_init.rs
@@ -53,14 +53,14 @@ pub fn codegen(app: &App, analysis: &Analysis, extra: &Extra) -> Vec<TokenStream
         let interrupt = util::interrupt_ident();
         stmts.push(quote!(
             core.NVIC.set_priority(
-                #device::#interrupt::#name,
+                you_must_enable_the_rt_feature_for_the_pac_in_your_cargo_toml::#interrupt::#name,
                 rtic::export::logical2hw(#priority, #nvic_prio_bits),
             );
         ));
 
         // NOTE unmask the interrupt *after* setting its priority: changing the priority of a pended
         // interrupt is implementation defined
-        stmts.push(quote!(rtic::export::NVIC::unmask(#device::#interrupt::#name);));
+        stmts.push(quote!(rtic::export::NVIC::unmask(you_must_enable_the_rt_feature_for_the_pac_in_your_cargo_toml::#interrupt::#name);));
     }
 
     // Set exception priorities

--- a/macros/src/codegen/spawn_body.rs
+++ b/macros/src/codegen/spawn_body.rs
@@ -10,7 +10,7 @@ pub fn codegen(
     name: &Ident,
     app: &App,
     analysis: &Analysis,
-    extra: &Extra,
+    _extra: &Extra,
 ) -> TokenStream2 {
     let spawnee = &app.software_tasks[name];
     let priority = spawnee.args.priority;
@@ -42,12 +42,11 @@ pub fn codegen(
         )
     };
 
-    let device = extra.device;
     let enum_ = util::interrupt_ident();
     let interrupt = &analysis.interrupts.get(&priority);
     let pend = {
         quote!(
-            rtic::pend(#device::#enum_::#interrupt);
+            rtic::pend(you_must_enable_the_rt_feature_for_the_pac_in_your_cargo_toml::#enum_::#interrupt);
         )
     };
 

--- a/macros/src/codegen/timer_queue.rs
+++ b/macros/src/codegen/timer_queue.rs
@@ -72,7 +72,6 @@ pub fn codegen(app: &App, analysis: &Analysis, extra: &Extra) -> Vec<TokenStream
 
         // Timer queue handler
         {
-            let device = extra.device;
             let arms = timer_queue
                 .tasks
                 .iter()
@@ -88,7 +87,7 @@ pub fn codegen(app: &App, analysis: &Analysis, extra: &Extra) -> Vec<TokenStream
 
                     let pend = {
                         quote!(
-                            rtic::pend(#device::#enum_::#interrupt);
+                            rtic::pend(you_must_enable_the_rt_feature_for_the_pac_in_your_cargo_toml::#enum_::#interrupt);
                         )
                     };
 

--- a/macros/src/codegen/util.rs
+++ b/macros/src/codegen/util.rs
@@ -83,7 +83,7 @@ pub fn instants_ident(task: &Ident) -> Ident {
 
 pub fn interrupt_ident() -> Ident {
     let span = Span::call_site();
-    Ident::new("Interrupt", span)
+    Ident::new("interrupt", span)
 }
 
 /// Whether `name` is an exception with configurable priority

--- a/ui/single/locals-cfg.stderr
+++ b/ui/single/locals-cfg.stderr
@@ -33,9 +33,3 @@ error: duplicate lang item in crate `panic_halt` (which `$CRATE` depends on): `p
   = note: the lang item is first defined in crate `std` (which `$CRATE` depends on)
   = note: first definition in `std` loaded from /usr/share/rust/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-f14aca24435a5414.rlib
   = note: second definition in `panic_halt` loaded from $DIR/target/tests/target/x86_64-unknown-linux-gnu/debug/deps/libpanic_halt-33949299fdfa2375.rmeta
-
-error: duplicate lang item in crate `panic_semihosting`: `panic_impl`.
-  |
-  = note: the lang item is first defined in crate `panic_halt` (which `$CRATE` depends on)
-  = note: first definition in `panic_halt` loaded from $DIR/target/tests/target/x86_64-unknown-linux-gnu/debug/deps/libpanic_halt-33949299fdfa2375.rmeta
-  = note: second definition in `panic_semihosting` loaded from $DIR/target/tests/target/x86_64-unknown-linux-gnu/debug/deps/libpanic_semihosting-f97442f9ee5cfc78.rmeta


### PR DESCRIPTION
This stops RTIC applications from compiling if one has forgotten to set the `rt` flag in the PAC/HAL.

The error:

```
error[E0433]: failed to resolve: could not find `interrupt` in `you_must_enable_the_rt_feature_for_the_pac_in_your_cargo_toml`
 --> src/main.rs:8:1
  |
8 | #[rtic::app(device = stm32l4xx_hal::pac)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `interrupt` in `you_must_enable_the_rt_feature_for_the_pac_in_your_cargo_toml`
  |
  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
```