### PR TITLE
Add the cfgs on a task to the module for that task

### DIFF
--- a/examples/cfg-whole-task.rs
+++ b/examples/cfg-whole-task.rs
@@ -1,0 +1,94 @@
+//! examples/cfg-whole-task.rs
+
+#![deny(unsafe_code)]
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use panic_semihosting as _;
+
+#[rtic::app(device = lm3s6965)]
+mod app {
+    use cortex_m_semihosting::debug;
+    #[cfg(debug_assertions)]
+    use cortex_m_semihosting::hprintln;
+
+    #[resources]
+    struct Resources {
+        #[cfg(debug_assertions)] // <- `true` when using the `dev` profile
+        #[init(0)]
+        count: u32,
+        #[cfg(never)]
+        #[init(0)]
+        unused: u32,
+    }
+
+    #[init]
+    fn init(_: init::Context) -> init::LateResources {
+        foo::spawn().unwrap();
+        foo::spawn().unwrap();
+
+        init::LateResources {}
+    }
+
+    #[idle]
+    fn idle(_: idle::Context) -> ! {
+        debug::exit(debug::EXIT_SUCCESS);
+
+        loop {
+            cortex_m::asm::nop();
+        }
+    }
+
+    #[task(capacity = 2, resources = [count])]
+    fn foo(_cx: foo::Context) {
+        #[cfg(debug_assertions)]
+        {
+            *_cx.resources.count += 1;
+
+            log::spawn(*_cx.resources.count).unwrap();
+        }
+
+        // this wouldn't compile in `release` mode
+        // *_cx.resources.count += 1;
+
+        // ..
+    }
+
+    // The whole task should disappear,
+    // currently still present in the Tasks enum
+    #[cfg(never)]
+    #[task(capacity = 2, resources = [count])]
+    fn foo2(_cx: foo2::Context) {
+        #[cfg(debug_assertions)]
+        {
+            *_cx.resources.count += 10;
+
+            log::spawn(*_cx.resources.count).unwrap();
+        }
+
+        // this wouldn't compile in `release` mode
+        // *_cx.resources.count += 1;
+
+        // ..
+    }
+
+    #[cfg(debug_assertions)]
+    #[task(capacity = 2)]
+    fn log(_: log::Context, n: u32) {
+        hprintln!(
+            "foo has been called {} time{}",
+            n,
+            if n == 1 { "" } else { "s" }
+        )
+        .ok();
+    }
+
+    // RTIC requires that unused interrupts are declared in an extern block when
+    // using software tasks; these free interrupts will be used to dispatch the
+    // software tasks.
+    extern "C" {
+        fn SSI0();
+        fn QEI0();
+    }
+}

--- a/macros/src/codegen/module.rs
+++ b/macros/src/codegen/module.rs
@@ -14,6 +14,8 @@ pub fn codegen(
     let mut items = vec![];
     let mut fields = vec![];
     let mut values = vec![];
+    // Used to copy task cfgs to the whole module
+    let mut task_cfgs = vec![];
 
     let name = ctxt.ident(app);
 
@@ -191,6 +193,8 @@ pub fn codegen(
         let priority = spawnee.args.priority;
         let t = util::spawn_t_ident(priority);
         let cfgs = &spawnee.cfgs;
+        // Store a copy of the task cfgs
+        task_cfgs = cfgs.clone();
         let (args, tupled, _untupled, ty) = util::regroup_inputs(&spawnee.inputs);
         let args = &args;
         let tupled = &tupled;
@@ -285,6 +289,7 @@ pub fn codegen(
 
         quote!(
             #[allow(non_snake_case)]
+            #(#task_cfgs)*
             #[doc = #doc]
             pub mod #name {
                 #(


### PR DESCRIPTION
Applying a `#[cfg(never)]` on a task:

before:

```
#[allow(non_snake_case)]
#[doc = "Software task"]
pub mod foo2 {
    #[doc(inline)]
    pub use super::foo2Resources as Resources;
    #[doc = r" Execution context"]
    pub struct Context<'a> {
        #[doc = r" Resources this task has access to"]
        pub resources: Resources<'a>,
    }
    impl<'a> Context<'a> {
        #[inline(always)]
        pub unsafe fn new(priority: &'a rtic::export::Priority) -> Self {
            Context {
                resources: Resources::new(priority),
            }
        }
    }
      <...>
```

After:

```
#[allow(non_snake_case)]
#[cfg(never)]
#[doc = "Software task"]
pub mod foo2 {
    #[doc(inline)]
    pub use super::foo2Resources as Resources;
    #[doc = r" Execution context"]
    pub struct Context<'a> {
        #[doc = r" Resources this task has access to"]
        pub resources: Resources<'a>,
    }
    impl<'a> Context<'a> {
        #[inline(always)]
        pub unsafe fn new(priority: &'a rtic::export::Priority) -> Self {
            Context {
                resources: Resources::new(priority),
            }
        }
    }
    <...>
```
