### PR TITLE
Bump required version of heapless to 0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ cortex-m = "0.6.2"
 cortex-m-rtic-macros = { path = "macros", version = "0.5.2" }
 rtic-core = "0.3.0"
 cortex-m-rt = "0.6.9"
-heapless = "0.5.0"
+heapless = "0.6.1"
 
 [build-dependencies]
 version_check = "0.9"


### PR DESCRIPTION
RTIC may be flagged by cargo audit since it depends on heapless 0.5.x.

That is because heapless <= 0.6.1 depends on generic-array with a [security issue](https://github.com/RustSec/advisory-db/pull/789)

UB bug as discussed here: https://github.com/japaric/heapless/issues/181 is also resolved in 0.6.1.