### PR TITLE
Fix the CI tests by using latest mdbook

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -628,9 +628,9 @@ jobs:
         run: pip install git+https://github.com/linkchecker/linkchecker.git
 
       - name: mdBook Action
-        uses: peaceiris/actions-mdbook@v1.1.11
+        uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.3.1'
+          mdbook-version: 'latest'
 
       - name: Build book in English
         run: cd book/en && mdbook build
@@ -682,10 +682,9 @@ jobs:
         run: python -c "import sys; print(sys.version)"
 
       - name: mdBook Action
-        uses: peaceiris/actions-mdbook@v1.1.11
+        uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.3.1'
-          # mdbook-version: 'latest'
+          mdbook-version: 'latest'
 
       - name: Remove cargo-config
         run: rm -f .cargo/config

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,6 @@ version = "0.1.0-alpha.2"
 
 [dev-dependencies]
 lm3s6965 = "0.1.3"
-panic-halt = "0.2.0"
 cortex-m-semihosting = "0.3.3"
 
 [dev-dependencies.panic-semihosting]

--- a/book/en/src/preface.md
+++ b/book/en/src/preface.md
@@ -18,8 +18,8 @@ There is a translation of this book in [Russian].
 
 This is the documentation of v0.5.x of RTIC; for the documentation of
 
-* development version go [here](/dev).
-* v0.4.x go [here](/0.4).
+* development version go [here](/dev/).
+* v0.4.x go [here](/0.4/).
 
 {{#include ../../../README.md:7:46}}
 

--- a/examples/not-send.rs
+++ b/examples/not-send.rs
@@ -8,7 +8,7 @@
 use core::marker::PhantomData;
 
 use cortex_m_semihosting::debug;
-use panic_halt as _;
+use panic_semihosting as _;
 use rtic::app;
 
 pub struct NotSend {

--- a/examples/not-sync.rs
+++ b/examples/not-sync.rs
@@ -8,7 +8,7 @@
 use core::marker::PhantomData;
 
 use cortex_m_semihosting::debug;
-use panic_halt as _;
+use panic_semihosting as _;
 
 pub struct NotSync {
     _0: PhantomData<*const ()>,

--- a/examples/schedule.rs
+++ b/examples/schedule.rs
@@ -7,7 +7,7 @@
 
 use cortex_m::peripheral::DWT;
 use cortex_m_semihosting::hprintln;
-use panic_halt as _;
+use panic_semihosting as _;
 use rtic::cyccnt::{Instant, U32Ext as _};
 
 // NOTE: does NOT work on QEMU!

--- a/examples/shared-with-init.rs
+++ b/examples/shared-with-init.rs
@@ -7,7 +7,7 @@
 
 use cortex_m_semihosting::debug;
 use lm3s6965::Interrupt;
-use panic_halt as _;
+use panic_semihosting as _;
 use rtic::app;
 
 pub struct MustBeSend;

--- a/examples/t-binds.rs
+++ b/examples/t-binds.rs
@@ -5,7 +5,7 @@
 #![no_main]
 #![no_std]
 
-use panic_halt as _;
+use panic_semihosting as _;
 
 #[rtic::app(device = lm3s6965)]
 const APP: () = {

--- a/examples/t-cfg-resources.rs
+++ b/examples/t-cfg-resources.rs
@@ -3,7 +3,7 @@
 #![no_main]
 #![no_std]
 
-use panic_halt as _;
+use panic_semihosting as _;
 
 #[rtic::app(device = lm3s6965)]
 const APP: () = {

--- a/examples/t-cfg.rs
+++ b/examples/t-cfg.rs
@@ -3,7 +3,7 @@
 #![no_main]
 #![no_std]
 
-use panic_halt as _;
+use panic_semihosting as _;
 
 #[rtic::app(device = lm3s6965, monotonic = rtic::cyccnt::CYCCNT)]
 const APP: () = {

--- a/examples/t-late-not-send.rs
+++ b/examples/t-late-not-send.rs
@@ -5,7 +5,7 @@
 
 use core::marker::PhantomData;
 
-use panic_halt as _;
+use panic_semihosting as _;
 
 pub struct NotSend {
     _0: PhantomData<*const ()>,

--- a/examples/t-resource.rs
+++ b/examples/t-resource.rs
@@ -5,7 +5,7 @@
 #![no_main]
 #![no_std]
 
-use panic_halt as _;
+use panic_semihosting as _;
 
 #[rtic::app(device = lm3s6965)]
 const APP: () = {

--- a/examples/t-schedule.rs
+++ b/examples/t-schedule.rs
@@ -5,7 +5,7 @@
 #![no_main]
 #![no_std]
 
-use panic_halt as _;
+use panic_semihosting as _;
 use rtic::cyccnt::{Instant, U32Ext as _};
 
 #[rtic::app(device = lm3s6965, monotonic = rtic::cyccnt::CYCCNT)]

--- a/examples/t-spawn.rs
+++ b/examples/t-spawn.rs
@@ -5,7 +5,7 @@
 #![no_main]
 #![no_std]
 
-use panic_halt as _;
+use panic_semihosting as _;
 
 #[rtic::app(device = lm3s6965)]
 const APP: () = {

--- a/ui/single/locals-cfg.stderr
+++ b/ui/single/locals-cfg.stderr
@@ -27,11 +27,3 @@ error[E0425]: cannot find value `FOO` in this scope
    |
 44 |         FOO;
    |         ^^^ not found in this scope
-
-error: duplicate lang item in crate `panic_halt`: `panic_impl`.
-  |
-  = note: first defined in crate `std`.
-
-error: duplicate lang item in crate `panic_semihosting`: `panic_impl`.
-  |
-  = note: first defined in crate `panic_halt`.

--- a/ui/single/task-priority-too-high.rs
+++ b/ui/single/task-priority-too-high.rs
@@ -1,7 +1,5 @@
 #![no_main]
 
-use rtic::app;
-
 #[rtic::app(device = lm3s6965)]
 const APP: () = {
     #[init]

--- a/ui/single/task-priority-too-high.stderr
+++ b/ui/single/task-priority-too-high.stderr
@@ -1,13 +1,5 @@
-warning: unused import: `rtic::app`
- --> $DIR/task-priority-too-high.rs:3:5
-  |
-3 | use rtic::app;
-  |     ^^^^^^^^^
-  |
-  = note: #[warn(unused_imports)] on by default
-
 error[E0080]: evaluation of constant value failed
- --> $DIR/task-priority-too-high.rs:5:1
+ --> $DIR/task-priority-too-high.rs:3:1
   |
-5 | #[rtic::app(device = lm3s6965)]
+3 | #[rtic::app(device = lm3s6965)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to subtract with overflow


### PR DESCRIPTION
Tests are broken as of now with error message:

```

Run peaceiris/actions-mdbook@v1.1.11
mdbook version: 0.3.1
Operating System: unknown-linux-gnu
toolURL: https://github.com/rust-lang/mdBook/releases/download/v0.3.1/mdbook-v0.3.1-x86_64-unknown-linux-gnu.tar.gz
Error: Unable to process command '::add-path::/home/runner/toolbin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
/usr/bin/tar xz --warning=no-unknown-keyword -C /home/runner/tmp -f /home/runner/work/_temp/fbe86fac-52b6-41ee-8e08-291c543d38bf
/home/runner/toolbin/mdbook --version
mdbook v0.3.1
```

Updating to latest mdbook hopefully solves this issue