### PR TITLE
Add periodic GHA job to run cargo audit

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,0 +1,12 @@
+name: Security audit
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  audit:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/properties/audit.properties.json
+++ b/.github/workflows/properties/audit.properties.json
@@ -1,0 +1,6 @@
+{
+    "name": "Audit",
+    "description": "Cargo audit",
+    "iconName": "rust",
+    "categories": ["Rust"]
+}


### PR DESCRIPTION
With the recent generic-array issue affecting heapless it seems wise to stay up to date with the latest advisories.