### PR TITLE
reclaim stack space used in late init

### DIFF
--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -66,9 +66,17 @@ pub fn app(app: &App, analysis: &Analysis, extra: &Extra) -> TokenStream2 {
 
                 #(#pre_init_stmts)*
 
-                #call_init
+                #[inline(never)]
+                fn __rtic_init_resources<F>(f: F) where F: FnOnce() {
+                    f();
+                }
 
-                #(#post_init_stmts)*
+                // Wrap late_init_stmts in a function to ensure that stack space is reclaimed.
+                __rtic_init_resources(||{
+                    #call_init
+
+                    #(#post_init_stmts)*
+                });
 
                 #call_idle
             }


### PR DESCRIPTION
Fixes #474.

Tested that there is no longer any stack overhead leftover from moving init resources.

(made mistake force pushing with last PR when trying to fix lint)

The expansion for an example with 2 buffers as resources changes from:


```rust
let (late, mut monotonics) = crate::APP::init(init::Context::new(core.into()));
__rtic_internal_mybuffer.as_mut_ptr().write(late.mybuffer);
__rtic_internal_mybuffer2.as_mut_ptr().write(late.mybuffer2);
rtic::export::interrupt::enable();
crate::APP::idle(idle::Context::new(&rtic::export::Priority::new(0)))
```

to:

```rust
#[inline(never)]
fn __rtic_init_resources<F>(f: F)
where
    F: FnOnce(),
{
    f();
}
__rtic_init_resources(|| {
    let (late, mut monotonics) = crate::APP::init(init::Context::new(core.into()));
    __rtic_internal_mybuffer.as_mut_ptr().write(late.mybuffer);
    __rtic_internal_mybuffer2.as_mut_ptr().write(late.mybuffer2);
    rtic::export::interrupt::enable();
});
crate::APP::idle(idle::Context::new(&rtic::export::Priority::new(0)))
```