### PR TITLE
book/migration/v5: update init signature, fix example syntax

### DIFF
--- a/book/en/src/migration/migration_v5.md
+++ b/book/en/src/migration/migration_v5.md
@@ -71,14 +71,14 @@ From this:
 
 ``` rust
 #[rtic::app(device = lm3s6965)]
-mod app {
+const APP: () = {
     #[init]
     fn init(_: init::Context) {
         rtic::pend(Interrupt::UART0);
     }
 
     // [more code]
-}
+};
 ```
 
 to this:
@@ -87,10 +87,10 @@ to this:
 #[rtic::app(device = lm3s6965)]
 mod app {
     #[init]
-    fn init(_: init::Context) -> init::LateResources {
+    fn init(_: init::Context) -> (init::LateResources, init::Monotonics) {
         rtic::pend(Interrupt::UART0);
 
-        init::LateResources {}
+        (init::LateResources {}, init::Monotonics())
     }
 
     // [more code]


### PR DESCRIPTION
From the comment in #478.

The example now migrates from v5 to v6 instead of an incorrect v6 syntax
to a another incorrect v6 syntax.