### PR TITLE
Reference monotonics by type alias

### DIFF
--- a/examples/schedule.rs
+++ b/examples/schedule.rs
@@ -14,8 +14,11 @@ mod app {
     use dwt_systick_monotonic::DwtSystick;
     use rtic::time::duration::Seconds;
 
+    /// 8 MHz
+    const MONO_HZ: u32 = 8_000_000;
+
     #[monotonic(binds = SysTick, default = true)]
-    type MyMono = DwtSystick<8_000_000>; // 8 MHz
+    type MyMono = DwtSystick<MONO_HZ>;
 
     #[init()]
     fn init(cx: init::Context) -> (init::LateResources, init::Monotonics) {
@@ -23,7 +26,7 @@ mod app {
         let dwt = cx.core.DWT;
         let systick = cx.core.SYST;
 
-        let mono = DwtSystick::new(&mut dcb, dwt, systick, 8_000_000);
+        let mono = DwtSystick::new(&mut dcb, dwt, systick, MONO_HZ);
 
         hprintln!("init").unwrap();
 


### PR DESCRIPTION
The PR tries to fix #470. I think we can correct the monotonic codegen with const generics by changing the way we reference user-defined monotonics.

Here's what the user does:

```rust
const MONO_HZ: u32 = 8_000_000;

#[monotonic(binds = SysTick, default = true)]
type MyMono = DwtSystick<MONO_HZ>;
```

Before this PR, RTIC generated code that referenced the monotonic by the right side of the type alias, `DwtSystick<MONO_HZ>`. RTIC could access the `DwtSystick` identifier from the user imports. But, RTIC doesn't seem to have a way to reference the `MONO_HZ` user-defined const.

As of this PR, RTIC references monotonics by the left side, `MyMono`. To disambiguate the type alias from the generated module of the same name (withing the `monotonics` module), we use an absolute path afforded by `app_path`.

Tested by compiling the `schedule.rs` example:

```
cargo build --example schedule --target thumbv7em-none-eabihf --all-features
```