### PR TITLE
Allow zero sized LinkedList

### DIFF
--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -566,6 +566,7 @@ mod tests {
     fn test_zero_size() {
         let ll: LinkedList<u32, Max, U0> = LinkedList::new();
 
+        assert!(ll.is_empty());
         assert!(ll.is_full());
     }
 

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -269,6 +269,11 @@ where
         let len = N::U16;
         let mut free = 0;
 
+        if len == 0 {
+            list.free = LinkedIndex::none();
+            return list;
+        }
+
         // Initialize indexes
         while free < len - 1 {
             unsafe {
@@ -555,6 +560,13 @@ mod tests {
         let ll: LinkedList<u32, Max, U3> = LinkedList::new();
 
         assert!(ll.is_empty())
+    }
+
+    #[test]
+    fn test_zero_size() {
+        let ll: LinkedList<u32, Max, U0> = LinkedList::new();
+
+        assert!(ll.is_full());
     }
 
     #[test]


### PR DESCRIPTION
If one configures a monotonic in alpha4, but doesn't use it, TimerQueue attempts to create a zero-sized LinkedList, which causes an underflow.

This PR allows for zero-sized linked lists.