### PR TITLE
Fix syntax error in migration guide

### DIFF
--- a/book/en/src/migration/migration_v5.md
+++ b/book/en/src/migration/migration_v5.md
@@ -68,7 +68,7 @@ mod app {
     fn func() {
         super::some_crate::some_func();
     }
-};
+}
 ```
 
 ## Move Dispatchers from `extern "C"` to app arguments.


### PR DESCRIPTION
Minor problem with a minor fix.