### PR TITLE
backport: "you must enable the rt feature" compile time detection

### DIFF
--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -120,6 +120,7 @@ pub fn app(app: &App, analysis: &Analysis, extra: &Extra) -> TokenStream2 {
 
     let name = &app.name;
     let device = extra.device;
+    let rt_err = util::rt_err_ident();
     quote!(
         #(#user)*
 
@@ -139,7 +140,7 @@ pub fn app(app: &App, analysis: &Analysis, extra: &Extra) -> TokenStream2 {
         // the user can't access the items within this `const` item
         const #name: () = {
             /// Always include the device crate which contains the vector table
-            use #device as _;
+            use #device as #rt_err;
 
             #check_excess_cores
 

--- a/macros/src/codegen/pre_init.rs
+++ b/macros/src/codegen/pre_init.rs
@@ -52,6 +52,7 @@ pub fn codegen(
     }
 
     let device = extra.device;
+    let rt_err = util::rt_err_ident();
     let nvic_prio_bits = quote!(#device::NVIC_PRIO_BITS);
 
     // unmask interrupts and set their priorities
@@ -76,14 +77,14 @@ pub fn codegen(
         let interrupt = util::interrupt_ident(core, app.args.cores);
         stmts.push(quote!(
             core.NVIC.set_priority(
-                #device::#interrupt::#name,
+                #rt_err::#interrupt::#name,
                 rtic::export::logical2hw(#priority, #nvic_prio_bits),
             );
         ));
 
         // NOTE unmask the interrupt *after* setting its priority: changing the priority of a pended
         // interrupt is implementation defined
-        stmts.push(quote!(rtic::export::NVIC::unmask(#device::#interrupt::#name);));
+        stmts.push(quote!(rtic::export::NVIC::unmask(#rt_err::#interrupt::#name);));
     }
 
     // cross-spawn barriers: now that priorities have been set and the interrupts have been unmasked

--- a/macros/src/codegen/spawn_body.rs
+++ b/macros/src/codegen/spawn_body.rs
@@ -10,7 +10,7 @@ pub fn codegen(
     name: &Ident,
     app: &App,
     analysis: &Analysis,
-    extra: &Extra,
+    _extra: &Extra,
 ) -> TokenStream2 {
     let sender = spawner.core(app);
     let spawnee = &app.software_tasks[name];
@@ -44,16 +44,16 @@ pub fn codegen(
         )
     };
 
-    let device = extra.device;
+    let rt_err = util::rt_err_ident();
     let enum_ = util::interrupt_ident(receiver, app.args.cores);
     let interrupt = &analysis.interrupts[&receiver][&priority];
     let pend = if sender != receiver {
         quote!(
-            #device::xpend(#receiver, #device::#enum_::#interrupt);
+            #rt_err::xpend(#receiver, #rt_err::#enum_::#interrupt);
         )
     } else {
         quote!(
-            rtic::pend(#device::#enum_::#interrupt);
+            rtic::pend(#rt_err::#enum_::#interrupt);
         )
     };
 

--- a/macros/src/codegen/timer_queue.rs
+++ b/macros/src/codegen/timer_queue.rs
@@ -79,7 +79,7 @@ pub fn codegen(app: &App, analysis: &Analysis, extra: &Extra) -> Vec<TokenStream
 
         // Timer queue handler
         {
-            let device = extra.device;
+            let rt_err = util::rt_err_ident();
             let arms = timer_queue
                 .tasks
                 .iter()
@@ -96,11 +96,11 @@ pub fn codegen(app: &App, analysis: &Analysis, extra: &Extra) -> Vec<TokenStream
 
                     let pend = if sender != receiver {
                         quote!(
-                            #device::xpend(#receiver, #device::#enum_::#interrupt);
+                            #rt_err::xpend(#receiver, #rt_err::#enum_::#interrupt);
                         )
                     } else {
                         quote!(
-                            rtic::pend(#device::#enum_::#interrupt);
+                            rtic::pend(#rt_err::#enum_::#interrupt);
                         )
                     };
 

--- a/macros/src/codegen/util.rs
+++ b/macros/src/codegen/util.rs
@@ -325,5 +325,8 @@ pub fn tq_ident(core: Core) -> Ident {
 }
 
 pub fn rt_err_ident() -> Ident {
-    Ident::new("you_must_enable_the_rt_feature_for_the_pac_in_your_cargo_toml", Span::call_site())
+    Ident::new(
+        "you_must_enable_the_rt_feature_for_the_pac_in_your_cargo_toml",
+        Span::call_site(),
+    )
 }

--- a/macros/src/codegen/util.rs
+++ b/macros/src/codegen/util.rs
@@ -323,3 +323,7 @@ pub fn suffixed(name: &str, core: u8) -> Ident {
 pub fn tq_ident(core: Core) -> Ident {
     Ident::new(&format!("TQ{}", core), Span::call_site())
 }
+
+pub fn rt_err_ident() -> Ident {
+    Ident::new("you_must_enable_the_rt_feature_for_the_pac_in_your_cargo_toml", Span::call_site())
+}

--- a/macros/src/codegen/util.rs
+++ b/macros/src/codegen/util.rs
@@ -109,7 +109,7 @@ pub fn instants_ident(task: &Ident, sender: Core) -> Ident {
 pub fn interrupt_ident(core: Core, cores: u8) -> Ident {
     let span = Span::call_site();
     if cores == 1 {
-        Ident::new("Interrupt", span)
+        Ident::new("interrupt", span)
     } else {
         Ident::new(&format!("Interrupt_{}", core), span)
     }


### PR DESCRIPTION
NOTE: this is pull request against v0.5.x, not the main branch

what the title says: this backports the detection mechanism that tells you to enable the "rt" feature of the PAC when you forget to enable it