### PR TITLE
Make Priority::get() public.

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -94,7 +94,7 @@ impl Priority {
 
     /// Get the current priority
     #[inline(always)]
-    fn get(&self) -> u8 {
+    pub fn get(&self) -> u8 {
         self.inner.get()
     }
 }


### PR DESCRIPTION
This will allow to safely get priority of a current task and implement various loggers with lockless queues for each priority level.