### PR TITLE
book: update the resources chapter

### DIFF
--- a/book/en/src/by-example/resources.md
+++ b/book/en/src/by-example/resources.md
@@ -97,11 +97,15 @@ $ cargo run --example only-shared-access
 
 ## Lock-free resource access of mutable resources
 
-There exists two other options dealing with resources
+A critical section is *not* required to access a `#[shared]` resource that's only accessed by tasks running at the *same* priority.
+In this case, you can opt out of the `lock` API by adding the `#[lock_free]` field-level attribute to the resource declaration (see example below).
+Note that this is merely a convenience: if you do use the `lock` API, at runtime the framework will *not* produce a critical section.
 
-* `#[lock_free]`: there might be several tasks with the same priority
-  accessing the resource without critical section. Since tasks with the
-  same priority never can preempt another task on the same priority
-  this is safe.
-* `#[task_local]`: there must be only one task using this resource,
-  similar to a `static mut` task local resource, but (optionally) set-up by init.
+``` rust
+{{#include ../../../../examples/lock-free.rs}}
+```
+
+``` console
+$ cargo run --example lock-free
+{{#include ../../../../ci/expected/lock-free.run}}
+```

--- a/ci/expected/lock-free.run
+++ b/ci/expected/lock-free.run
@@ -1,0 +1,14 @@
+GPIOA/start
+  GPIOA/counter = 1
+GPIOA/end
+GPIOB/start
+  GPIOB/counter = 2
+GPIOB/end
+GPIOA/start
+  GPIOA/counter = 3
+GPIOA/end
+GPIOB/start
+  GPIOB/counter = 4
+GPIOB/end
+GPIOA/start
+  GPIOA/counter = 5

--- a/ci/expected/resource.run
+++ b/ci/expected/resource.run
@@ -1,2 +1,2 @@
 UART1: local_to_uart1 = 1
-UART0: local_to_uart0 = 2
+UART0: local_to_uart0 = 1

--- a/ci/expected/resource.run
+++ b/ci/expected/resource.run
@@ -1,2 +1,2 @@
-UART1: shared = 1
-UART0: shared = 2
+UART1: local_to_uart1 = 1
+UART0: local_to_uart0 = 2

--- a/examples/lock-free.rs
+++ b/examples/lock-free.rs
@@ -1,0 +1,60 @@
+//! examples/lock-free.rs
+
+#![deny(unsafe_code)]
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use panic_semihosting as _;
+
+#[rtic::app(device = lm3s6965)]
+mod app {
+    use cortex_m_semihosting::{debug, hprintln};
+    use lm3s6965::Interrupt;
+
+    #[shared]
+    struct Shared {
+        #[lock_free] // <- lock-free shared resource
+        counter: u64,
+    }
+
+    #[local]
+    struct Local {}
+
+    #[init]
+    fn init(_: init::Context) -> (Shared, Local, init::Monotonics) {
+        rtic::pend(Interrupt::GPIOA);
+
+        (Shared { counter: 0 }, Local {}, init::Monotonics())
+    }
+
+    #[task(binds = GPIOA, shared = [counter])] // <- same priority
+    fn gpioa(c: gpioa::Context) {
+        hprintln!("GPIOA/start").unwrap();
+        rtic::pend(Interrupt::GPIOB);
+
+        *c.shared.counter += 1; // <- no lock API required
+        let counter = *c.shared.counter;
+        hprintln!("  GPIOA/counter = {}", counter).unwrap();
+
+        if counter == 5 {
+            debug::exit(debug::EXIT_SUCCESS);
+        }
+        hprintln!("GPIOA/end").unwrap();
+    }
+
+    #[task(binds = GPIOB, shared = [counter])] // <- same priority
+    fn gpiob(c: gpiob::Context) {
+        hprintln!("GPIOB/start").unwrap();
+        rtic::pend(Interrupt::GPIOA);
+
+        *c.shared.counter += 1; // <- no lock API required
+        let counter = *c.shared.counter;
+        hprintln!("  GPIOB/counter = {}", counter).unwrap();
+
+        if counter == 5 {
+            debug::exit(debug::EXIT_SUCCESS);
+        }
+        hprintln!("GPIOB/end").unwrap();
+    }
+}

--- a/examples/resource.rs
+++ b/examples/resource.rs
@@ -61,7 +61,7 @@ mod app {
         let local_to_uart0 = cx.local.local_to_uart0;
 
         // error: no `local_to_uart1` field in `uart0::LocalResources`
-        cx.local.local_to_uart1 += 1;
+        // cx.local.local_to_uart1 += 1;
 
         hprintln!("UART0: local_to_uart0 = {}", local_to_uart0).unwrap();
     }

--- a/examples/resource.rs
+++ b/examples/resource.rs
@@ -13,55 +13,68 @@ mod app {
     use lm3s6965::Interrupt;
 
     #[shared]
-    struct Shared {
-        shared: u32,
-    }
+    struct Shared {}
 
     #[local]
-    struct Local {}
+    struct Local {
+        local_to_uart0: i64,
+        local_to_uart1: i64,
+    }
 
     #[init]
     fn init(_: init::Context) -> (Shared, Local, init::Monotonics) {
         rtic::pend(Interrupt::UART0);
         rtic::pend(Interrupt::UART1);
 
-        (Shared { shared: 0 }, Local {}, init::Monotonics())
+        (
+            Shared {},
+            Local {
+                local_to_uart0: 0,
+                local_to_uart1: 0,
+            },
+            init::Monotonics(),
+        )
     }
 
-    // `shared` cannot be accessed from this context
+    // `#[local]` resources cannot be accessed from this context
     #[idle]
     fn idle(_cx: idle::Context) -> ! {
         debug::exit(debug::EXIT_SUCCESS);
 
-        // error: no `shared` field in `idle::Context`
-        // _cx.shared.shared += 1;
+        // error: no `local` field in `idle::Context`
+        // _cx.local.local_to_uart0 += 1;
+
+        // error: no `local` field in `idle::Context`
+        // _cx.local.local_to_uart1 += 1;
 
         loop {
             cortex_m::asm::nop();
         }
     }
 
-    // `shared` can be accessed from this context
+    // `local_to_uart0` can only be accessed from this context
     // defaults to priority 1
-    #[task(binds = UART0, shared = [shared])]
-    fn uart0(mut cx: uart0::Context) {
-        let shared = cx.shared.shared.lock(|shared| {
-            *shared += 1;
-            *shared
-        });
+    #[task(binds = UART0, local = [local_to_uart0])]
+    fn uart0(cx: uart0::Context) {
+        *cx.local.local_to_uart0 += 1;
+        let local_to_uart0 = cx.local.local_to_uart0;
 
-        hprintln!("UART0: shared = {}", shared).unwrap();
+        // error: no `local_to_uart1` field in `uart0::LocalResources`
+        cx.local.local_to_uart1 += 1;
+
+        hprintln!("UART0: local_to_uart0 = {}", local_to_uart0).unwrap();
     }
 
-    // `shared` can be accessed from this context
+    // `shared` can only be accessed from this context
     // explicitly set to priority 2
-    #[task(binds = UART1, shared = [shared], priority = 2)]
-    fn uart1(mut cx: uart1::Context) {
-        let shared = cx.shared.shared.lock(|shared| {
-            *shared += 1;
-            *shared
-        });
+    #[task(binds = UART1, local = [local_to_uart1], priority = 2)]
+    fn uart1(cx: uart1::Context) {
+        *cx.local.local_to_uart1 += 1;
+        let local_to_uart1 = cx.local.local_to_uart1;
 
-        hprintln!("UART1: shared = {}", shared).unwrap();
+        // error: no `local_to_uart0` field in `uart1::LocalResources`
+        // cx.local.local_to_uart0 += 1;
+
+        hprintln!("UART1: local_to_uart1 = {}", local_to_uart1).unwrap();
     }
 }

--- a/examples/resource.rs
+++ b/examples/resource.rs
@@ -28,6 +28,7 @@ mod app {
 
         (
             Shared {},
+            // initial values for the `#[local]` resources
             Local {
                 local_to_uart0: 0,
                 local_to_uart1: 0,


### PR DESCRIPTION
see individual commit messages for details.

what's still left to do is adjust the very last section about `#[task_local]` and `#[lock_free]` but I plan to do that as a follow up. I didn't find an in-tree example for those two attributes (are they field attributes? where do they fit in the syntax?); a quick scan of the rtic-syntax crate seems to indicate that `task_local` has been removed (?) and that `lock_free` still exists.