### PR TITLE
Propogate the task attributes to the spawn handles

### DIFF
--- a/macros/src/codegen/module.rs
+++ b/macros/src/codegen/module.rs
@@ -317,11 +317,13 @@ pub fn codegen(
             ));
 
             items.push(quote!(
+                #(#cfgs)*
                 pub struct #internal_spawn_handle_ident {
                     #[doc(hidden)]
                     marker: u32,
                 }
 
+                #(#cfgs)*
                 impl #internal_spawn_handle_ident {
                     pub fn cancel(self) -> Result<#ty, ()> {
                         rtic::export::interrupt::free(|_| unsafe {


### PR DESCRIPTION
This allows tasks to be gated by `cfg` attributes when also using
monotonics. For example:

```rust
#[cfg(feature = "logging")]
#[task(shared = [logger])]
fn logger_init(mut cx: logger_init::Context) {
    /* ... */
}
```

Without this change, the reschedule_at() implementation is
unconditionally included even though it references the SpawnHandle from
its task module, which is _conditionally_ included. This resulted in
compiler errors like the following:

```
error[E0433]: failed to resolve: use of undeclared crate or module `logger_init`
   --> src/main.rs:243:8
    |
243 |     fn logger_init(mut cx: logger_init::Context) {
    |        ^^^^^^^^^^^ use of undeclared crate or module `logger_init`
```