### PR TITLE
book: Add note to remember to choose target

### DIFF
--- a/book/en/src/by-example/app.md
+++ b/book/en/src/by-example/app.md
@@ -53,6 +53,10 @@ $ cargo run --example init
 {{#include ../../../../ci/expected/init.run}}
 ```
 
+> **NOTE**: Remember to always specify your chosen target device or configure
+> one to be used by default in `.cargo/config.toml`. In this case, we use
+> a Cortex M3 running in QEMU so the target is `thumbv7m-none-eabi`.
+
 ## `idle`
 
 A function marked with the `idle` attribute can optionally appear in the
@@ -120,7 +124,7 @@ crate. When the `priority` argument is omitted, the priority is assumed to be
 `1`. The `idle` task has a non-configurable static priority of `0`, the lowest priority.
 
 > A higher number means a higher priority in RTIC, which is the opposite from what
-> Cortex-M does in the NVIC peripheral.  
+> Cortex-M does in the NVIC peripheral.
 > Explicitly, this means that number `10` has a **higher** priority than number `9`.
 
 When several tasks are ready to be executed the one with highest static


### PR DESCRIPTION
While following the instructions in the book I ran into a wall. I was getting linker errors and had no idea why. Turns out trying to run `cargo build --example init` on an x86 build target maybe doesn't work too well, so I added a note about it. :sweat_smile:

I'll leave this as a draft since my Russian isn't fluent enough to add the note there as well. Also, adding a modified version of `.config/cargo.toml` from the embedded example might be a decent idea but wanted to hear from you guys first. :P