### PR TITLE
Use cortex-m `InterruptNumber` instead of bare_metal `Nr`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m-rtic"
 readme = "README.md"
 repository = "https://github.com/rtic-rs/cortex-m-rtic"
-version = "0.5.7"
+version = "0.5.8"
 
 [lib]
 name = "rtic"
@@ -51,7 +51,7 @@ name = "types"
 required-features = ["__v7"]
 
 [dependencies]
-cortex-m = "0.6.2"
+cortex-m = "0.7.3"
 cortex-m-rtic-macros = { path = "macros", version = "0.5.3" }
 rtic-core = "0.3.0"
 cortex-m-rt = "0.6.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,20 @@ name = "types"
 required-features = ["__v7"]
 
 [dependencies]
-cortex-m = "0.7.3"
 cortex-m-rtic-macros = { path = "macros", version = "0.5.3" }
 rtic-core = "0.3.0"
 cortex-m-rt = "0.6.9"
 heapless = "0.6.1"
+
+[dependencies.cortex-m]
+package = "cortex-m"
+version = "0.6.2"
+optional = true
+
+[dependencies.cortex-m-7]
+package = "cortex-m"
+version = "0.7.3"
+optional = true
 
 [build-dependencies]
 version_check = "0.9"
@@ -65,7 +74,9 @@ optional = true
 version = "0.1.0-alpha.2"
 
 [dev-dependencies]
-lm3s6965 = "0.1.3"
+# The difference between this git version and the crates.io version is that this version implements Copy & Clone on Interrupt
+# which is needed for the cortex-m-7 feature (to use InterruptNumber instead of Nr on interrups)
+lm3s6965 = { git = "https://github.com/japaric/lm3s6965.git", version= "0.1.3", rev = "facf63aa0169c773175a143f6014a1d0977fb74f" }
 cortex-m-semihosting = "0.3.3"
 
 [dev-dependencies.panic-semihosting]
@@ -76,6 +87,7 @@ version = "0.5.2"
 trybuild = "1"
 
 [features]
+default = ["cortex-m"]
 heterogeneous = ["cortex-m-rtic-macros/heterogeneous", "microamp"]
 homogeneous = ["cortex-m-rtic-macros/homogeneous"]
 # used for testing this crate; do not use in applications

--- a/heterogeneous/Cargo.toml
+++ b/heterogeneous/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 version = "0.0.0-alpha.0"
 
 [dependencies]
-bare-metal = "0.2.4"
+cortex-m = "0.7.3"
 
 [dependencies.cortex-m-rtic]
 path = ".."

--- a/heterogeneous/Cargo.toml
+++ b/heterogeneous/Cargo.toml
@@ -7,11 +7,16 @@ publish = false
 version = "0.0.0-alpha.0"
 
 [dependencies]
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.3", optional = true }
+bare-metal = { version = "0.2.4", optional = true }
 
 [dependencies.cortex-m-rtic]
 path = ".."
 features = ["heterogeneous"]
+
+[features]
+default = ["bare-metal"]
+cortex-m-7 = ["cortex-m"]
 
 [dev-dependencies]
 panic-halt = "0.2.0"

--- a/heterogeneous/src/lib.rs
+++ b/heterogeneous/src/lib.rs
@@ -7,7 +7,7 @@ use core::{
     ops::{Add, Sub},
 };
 
-use bare_metal::Nr;
+use cortex_m::interrupt::InterruptNumber;
 use rtic::{Fraction, Monotonic, MultiCore};
 
 // both cores have the exact same interrupts
@@ -16,7 +16,7 @@ pub use Interrupt_0 as Interrupt_1;
 // Fake priority bits
 pub const NVIC_PRIO_BITS: u8 = 3;
 
-pub fn xpend(_core: u8, _interrupt: impl Nr) {}
+pub fn xpend(_core: u8, _interrupt: impl InterruptNumber) {}
 
 /// Fake monotonic timer
 pub struct MT;
@@ -92,8 +92,8 @@ pub enum Interrupt_0 {
     I7 = 7,
 }
 
-unsafe impl Nr for Interrupt_0 {
-    fn nr(&self) -> u8 {
-        *self as u8
+unsafe impl InterruptNumber for Interrupt_0 {
+    fn number(self) -> u16 {
+        self as u16
     }
 }

--- a/heterogeneous/src/lib.rs
+++ b/heterogeneous/src/lib.rs
@@ -7,6 +7,9 @@ use core::{
     ops::{Add, Sub},
 };
 
+#[cfg(feature = "bare-metal")]
+use bare_metal::Nr;
+#[cfg(feature = "cortex-m-7")]
 use cortex_m::interrupt::InterruptNumber;
 use rtic::{Fraction, Monotonic, MultiCore};
 
@@ -16,6 +19,9 @@ pub use Interrupt_0 as Interrupt_1;
 // Fake priority bits
 pub const NVIC_PRIO_BITS: u8 = 3;
 
+#[cfg(feature = "bare-metal")]
+pub fn xpend(_core: u8, _interrupt: impl Nr) {}
+#[cfg(feature = "cortex-m-7")]
 pub fn xpend(_core: u8, _interrupt: impl InterruptNumber) {}
 
 /// Fake monotonic timer
@@ -92,6 +98,14 @@ pub enum Interrupt_0 {
     I7 = 7,
 }
 
+#[cfg(feature = "bare-metal")]
+unsafe impl Nr for Interrupt_0 {
+    fn nr(&self) -> u8 {
+        *self as u8
+    }
+}
+
+#[cfg(feature = "cortex-m-7")]
 unsafe impl InterruptNumber for Interrupt_0 {
     fn number(self) -> u16 {
         self as u16

--- a/homogeneous/Cargo.toml
+++ b/homogeneous/Cargo.toml
@@ -7,11 +7,16 @@ publish = false
 version = "0.0.0-alpha.0"
 
 [dependencies]
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.3", optional = true }
+bare-metal = { version = "0.2.4", optional = true }
 
 [dependencies.cortex-m-rtic]
 path = ".."
 features = ["homogeneous"]
+
+[features]
+default = ["bare-metal"]
+cortex-m-7 = ["cortex-m"]
 
 [dev-dependencies]
 panic-halt = "0.2.0"

--- a/homogeneous/Cargo.toml
+++ b/homogeneous/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 version = "0.0.0-alpha.0"
 
 [dependencies]
-bare-metal = "0.2.4"
+cortex-m = "0.7.3"
 
 [dependencies.cortex-m-rtic]
 path = ".."

--- a/homogeneous/src/lib.rs
+++ b/homogeneous/src/lib.rs
@@ -7,7 +7,7 @@ use core::{
     ops::{Add, Sub},
 };
 
-use bare_metal::Nr;
+use cortex_m::interrupt::InterruptNumber;
 use rtic::{Fraction, Monotonic, MultiCore};
 
 // both cores have the exact same interrupts
@@ -16,7 +16,7 @@ pub use Interrupt_0 as Interrupt_1;
 // Fake priority bits
 pub const NVIC_PRIO_BITS: u8 = 3;
 
-pub fn xpend(_core: u8, _interrupt: impl Nr) {}
+pub fn xpend(_core: u8, _interrupt: impl InterruptNumber) {}
 
 /// Fake monotonic timer
 pub struct MT;
@@ -92,8 +92,8 @@ pub enum Interrupt_0 {
     I7 = 7,
 }
 
-unsafe impl Nr for Interrupt_0 {
-    fn nr(&self) -> u8 {
-        *self as u8
+unsafe impl InterruptNumber for Interrupt_0 {
+    fn number(self) -> u16 {
+        self as u16
     }
 }

--- a/homogeneous/src/lib.rs
+++ b/homogeneous/src/lib.rs
@@ -7,6 +7,9 @@ use core::{
     ops::{Add, Sub},
 };
 
+#[cfg(feature = "bare-metal")]
+use bare_metal::Nr;
+#[cfg(feature = "cortex-m-7")]
 use cortex_m::interrupt::InterruptNumber;
 use rtic::{Fraction, Monotonic, MultiCore};
 
@@ -16,6 +19,9 @@ pub use Interrupt_0 as Interrupt_1;
 // Fake priority bits
 pub const NVIC_PRIO_BITS: u8 = 3;
 
+#[cfg(feature = "bare-metal")]
+pub fn xpend(_core: u8, _interrupt: impl Nr) {}
+#[cfg(feature = "cortex-m-7")]
 pub fn xpend(_core: u8, _interrupt: impl InterruptNumber) {}
 
 /// Fake monotonic timer
@@ -92,6 +98,14 @@ pub enum Interrupt_0 {
     I7 = 7,
 }
 
+#[cfg(feature = "bare-metal")]
+unsafe impl Nr for Interrupt_0 {
+    fn nr(&self) -> u8 {
+        *self as u8
+    }
+}
+
+#[cfg(feature = "cortex-m-7")]
 unsafe impl InterruptNumber for Interrupt_0 {
     fn number(self) -> u16 {
         self as u16

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,10 +44,15 @@
 
 use core::ops::Sub;
 
-use cortex_m::{
-    interrupt::InterruptNumber,
-    peripheral::{CBP, CPUID, DCB, DWT, FPB, FPU, ITM, MPU, NVIC, SCB, TPIU},
-};
+#[cfg(feature = "cortex-m")]
+use cortex_m::interrupt::Nr;
+
+#[cfg(feature = "cortex-m-7")]
+extern crate cortex_m_7 as cortex_m;
+#[cfg(feature = "cortex-m-7")]
+use cortex_m::interrupt::InterruptNumber;
+
+use cortex_m::peripheral::{CBP, CPUID, DCB, DWT, FPB, FPU, ITM, MPU, NVIC, SCB, TPIU};
 #[cfg(all(not(feature = "heterogeneous"), not(feature = "homogeneous")))]
 use cortex_m_rt as _; // vector table
 pub use cortex_m_rtic_macros::app;
@@ -168,6 +173,19 @@ pub trait MultiCore {}
 ///
 /// This is a convenience function around
 /// [`NVIC::pend`](../cortex_m/peripheral/struct.NVIC.html#method.pend)
+#[cfg(feature = "cortex-m")]
+pub fn pend<I>(interrupt: I)
+where
+    I: Nr,
+{
+    NVIC::pend(interrupt)
+}
+
+/// Sets the given `interrupt` as pending
+///
+/// This is a convenience function around
+/// [`NVIC::pend`](../cortex_m/peripheral/struct.NVIC.html#method.pend)
+#[cfg(feature = "cortex-m-7")]
 pub fn pend<I>(interrupt: I)
 where
     I: InterruptNumber,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 use core::ops::Sub;
 
 use cortex_m::{
-    interrupt::Nr,
+    interrupt::InterruptNumber,
     peripheral::{CBP, CPUID, DCB, DWT, FPB, FPU, ITM, MPU, NVIC, SCB, TPIU},
 };
 #[cfg(all(not(feature = "heterogeneous"), not(feature = "homogeneous")))]
@@ -170,7 +170,7 @@ pub trait MultiCore {}
 /// [`NVIC::pend`](../cortex_m/peripheral/struct.NVIC.html#method.pend)
 pub fn pend<I>(interrupt: I)
 where
-    I: Nr,
+    I: InterruptNumber,
 {
     NVIC::pend(interrupt)
 }


### PR DESCRIPTION
The trait `Nr`from crate `bare-metal` is deprecated in 1.0, and `cortex-m` moved to `InterruptNumber`, which new PACs are using. As a result, `cortex-m-rtic` does not compile when using newer PACs because the `Nr` trait is not implemented:

```
error[E0277]: the trait bound `Interrupt: Nr` is not satisfied
 --> src/main.rs:7:1
  |
7 | #[rtic::app(device = stm32wl::stm32wle5, peripherals = true)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Nr` is not implemented for `Interrupt`
  |
  = note: this error originates in the attribute macro `rtic::app` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Older PACs that still use `Nr` will still work because `cortex_m` implements `Nr` for `InterruptNumber`. This was tested using the minimal code at [https://github.com/jorgeig-space/rtic-test](https://github.com/jorgeig-space/rtic-test).