### PR TITLE
Silence rust-analyzer warnings on internal types

### DIFF
--- a/macros/src/codegen/local_resources_struct.rs
+++ b/macros/src/codegen/local_resources_struct.rs
@@ -89,6 +89,7 @@ pub fn codegen(ctxt: Context, needs_lt: &mut bool, app: &App) -> (TokenStream2, 
     let ident = util::mark_internal_ident(&ident);
     let item = quote!(
         #[allow(non_snake_case)]
+        #[allow(non_camel_case_types)]
         #[doc = #doc]
         pub struct #ident<#lt> {
             #(#fields,)*

--- a/macros/src/codegen/shared_resources_struct.rs
+++ b/macros/src/codegen/shared_resources_struct.rs
@@ -105,6 +105,7 @@ pub fn codegen(ctxt: Context, needs_lt: &mut bool, app: &App) -> (TokenStream2, 
     let ident = util::mark_internal_ident(&ident);
     let item = quote!(
         #[allow(non_snake_case)]
+        #[allow(non_camel_case_types)]
         #[doc = #doc]
         pub struct #ident<#lt> {
             #(#fields,)*


### PR DESCRIPTION
Continues the work started in #513
