### PR TITLE
`mark_internal_ident` cleanup

### DIFF
--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -108,7 +108,6 @@ pub fn app(app: &App, analysis: &Analysis, extra: &Extra) -> TokenStream2 {
             let name = &monotonic.ident;
             let name_str = &name.to_string();
             let ident = util::monotonic_ident(&name_str);
-            let ident = util::mark_internal_ident(&ident);
             let panic_str = &format!(
                 "Use of monotonic '{}' before it was passed to the runtime",
                 name_str

--- a/macros/src/codegen/dispatchers.rs
+++ b/macros/src/codegen/dispatchers.rs
@@ -45,7 +45,6 @@ pub fn codegen(app: &App, analysis: &Analysis, _extra: &Extra) -> Vec<TokenStrea
 
         let n = util::capacity_literal(channel.capacity as usize + 1);
         let rq = util::rq_ident(level);
-        let rq = util::mark_internal_ident(&rq);
         let (rq_ty, rq_expr) = {
             (
                 quote!(rtic::export::SCRQ<#t, #n>),
@@ -72,9 +71,7 @@ pub fn codegen(app: &App, analysis: &Analysis, _extra: &Extra) -> Vec<TokenStrea
                 let task = &app.software_tasks[name];
                 let cfgs = &task.cfgs;
                 let fq = util::fq_ident(name);
-                let fq = util::mark_internal_ident(&fq);
                 let inputs = util::inputs_ident(name);
-                let inputs = util::mark_internal_ident(&inputs);
                 let (_, tupled, pats, _) = util::regroup_inputs(&task.inputs);
 
                 quote!(

--- a/macros/src/codegen/local_resources.rs
+++ b/macros/src/codegen/local_resources.rs
@@ -24,7 +24,7 @@ pub fn codegen(
     for (name, res) in &app.local_resources {
         let cfgs = &res.cfgs;
         let ty = &res.ty;
-        let mangled_name = util::mark_internal_ident(&util::static_local_resource_ident(name));
+        let mangled_name = util::static_local_resource_ident(name);
 
         let attrs = &res.attrs;
         // late resources in `util::link_section_uninit`
@@ -51,10 +51,7 @@ pub fn codegen(
         let expr = &task_local.expr;
         let attrs = &task_local.attrs;
 
-        let mangled_name = util::mark_internal_ident(&util::declared_static_local_resource_ident(
-            resource_name,
-            &task_name,
-        ));
+        let mangled_name = util::declared_static_local_resource_ident(resource_name, &task_name);
 
         // For future use
         // let doc = format!(" RTIC internal: {}:{}", file!(), line!());

--- a/macros/src/codegen/local_resources_struct.rs
+++ b/macros/src/codegen/local_resources_struct.rs
@@ -44,11 +44,9 @@ pub fn codegen(ctxt: Context, needs_lt: &mut bool, app: &App) -> (TokenStream2, 
         };
 
         let mangled_name = if matches!(task_local, TaskLocal::External) {
-            util::mark_internal_ident(&util::static_local_resource_ident(name))
+            util::static_local_resource_ident(name)
         } else {
-            util::mark_internal_ident(&util::declared_static_local_resource_ident(
-                name, &task_name,
-            ))
+            util::declared_static_local_resource_ident(name, &task_name)
         };
 
         fields.push(quote!(
@@ -86,7 +84,6 @@ pub fn codegen(ctxt: Context, needs_lt: &mut bool, app: &App) -> (TokenStream2, 
 
     let doc = format!("Local resources `{}` has access to", ctxt.ident(app));
     let ident = util::local_resources_ident(ctxt, app);
-    let ident = util::mark_internal_ident(&ident);
     let item = quote!(
         #[allow(non_snake_case)]
         #[allow(non_camel_case_types)]

--- a/macros/src/codegen/module.rs
+++ b/macros/src/codegen/module.rs
@@ -67,7 +67,6 @@ pub fn codegen(
 
     if ctxt.has_local_resources(app) {
         let ident = util::local_resources_ident(ctxt, app);
-        let ident = util::mark_internal_ident(&ident);
         let lt = if local_resources_tick {
             lt = Some(quote!('a));
             Some(quote!('a))
@@ -90,7 +89,6 @@ pub fn codegen(
 
     if ctxt.has_shared_resources(app) {
         let ident = util::shared_resources_ident(ctxt, app);
-        let ident = util::mark_internal_ident(&ident);
         let lt = if shared_resources_tick {
             lt = Some(quote!('a));
             Some(quote!('a))
@@ -212,11 +210,8 @@ pub fn codegen(
         let args = &args;
         let tupled = &tupled;
         let fq = util::fq_ident(name);
-        let fq = util::mark_internal_ident(&fq);
         let rq = util::rq_ident(priority);
-        let rq = util::mark_internal_ident(&rq);
         let inputs = util::inputs_ident(name);
-        let inputs = util::mark_internal_ident(&inputs);
 
         let device = &extra.device;
         let enum_ = util::interrupt_ident();
@@ -266,16 +261,13 @@ pub fn codegen(
         // Schedule caller
         for (_, monotonic) in &app.monotonics {
             let instants = util::monotonic_instants_ident(name, &monotonic.ident);
-            let instants = util::mark_internal_ident(&instants);
             let monotonic_name = monotonic.ident.to_string();
 
             let tq = util::tq_ident(&monotonic.ident.to_string());
-            let tq = util::mark_internal_ident(&tq);
             let t = util::schedule_t_ident();
             let m = &monotonic.ident;
             let mono_type = &monotonic.ident;
             let m_ident = util::monotonic_ident(&monotonic_name);
-            let m_ident = util::mark_internal_ident(&m_ident);
             let m_isr = &monotonic.args.binds;
             let enum_ = util::interrupt_ident();
 
@@ -293,7 +285,7 @@ pub fn codegen(
                 )
             };
 
-            let tq_marker = util::mark_internal_ident(&util::timer_queue_marker_ident());
+            let tq_marker = &util::timer_queue_marker_ident();
 
             // For future use
             // let doc = format!(" RTIC internal: {}:{}", file!(), line!());

--- a/macros/src/codegen/post_init.rs
+++ b/macros/src/codegen/post_init.rs
@@ -11,7 +11,7 @@ pub fn codegen(app: &App, analysis: &Analysis) -> Vec<TokenStream2> {
 
     // Initialize shared resources
     for (name, res) in &app.shared_resources {
-        let mangled_name = util::mark_internal_ident(&util::static_shared_resource_ident(name));
+        let mangled_name = util::static_shared_resource_ident(name);
         // If it's live
         let cfgs = res.cfgs.clone();
         if analysis.shared_resource_locations.get(name).is_some() {
@@ -29,7 +29,7 @@ pub fn codegen(app: &App, analysis: &Analysis) -> Vec<TokenStream2> {
 
     // Initialize local resources
     for (name, res) in &app.local_resources {
-        let mangled_name = util::mark_internal_ident(&util::static_local_resource_ident(name));
+        let mangled_name = util::static_local_resource_ident(name);
         // If it's live
         let cfgs = res.cfgs.clone();
         if analysis.local_resource_locations.get(name).is_some() {
@@ -58,7 +58,6 @@ pub fn codegen(app: &App, analysis: &Analysis) -> Vec<TokenStream2> {
 
         // Store the monotonic
         let name = util::monotonic_ident(&monotonic.to_string());
-        let name = util::mark_internal_ident(&name);
         stmts.push(quote!(*#name.get_mut_unchecked() = Some(monotonics.#idx);));
     }
 

--- a/macros/src/codegen/pre_init.rs
+++ b/macros/src/codegen/pre_init.rs
@@ -17,7 +17,6 @@ pub fn codegen(app: &App, analysis: &Analysis, extra: &Extra) -> Vec<TokenStream
     for (name, task) in &app.software_tasks {
         let cap = task.args.capacity;
         let fq_ident = util::fq_ident(name);
-        let fq_ident = util::mark_internal_ident(&fq_ident);
 
         stmts.push(quote!(
             (0..#cap).for_each(|i| #fq_ident.get_mut_unchecked().enqueue_unchecked(i));

--- a/macros/src/codegen/shared_resources.rs
+++ b/macros/src/codegen/shared_resources.rs
@@ -21,7 +21,7 @@ pub fn codegen(
     for (name, res) in &app.shared_resources {
         let cfgs = &res.cfgs;
         let ty = &res.ty;
-        let mangled_name = util::mark_internal_ident(&util::static_shared_resource_ident(&name));
+        let mangled_name = &util::static_shared_resource_ident(&name);
 
         // late resources in `util::link_section_uninit`
         let section = util::link_section_uninit();

--- a/macros/src/codegen/shared_resources_struct.rs
+++ b/macros/src/codegen/shared_resources_struct.rs
@@ -32,7 +32,7 @@ pub fn codegen(ctxt: Context, needs_lt: &mut bool, app: &App) -> (TokenStream2, 
             None
         };
         let ty = &res.ty;
-        let mangled_name = util::mark_internal_ident(&util::static_shared_resource_ident(&name));
+        let mangled_name = util::static_shared_resource_ident(&name);
 
         if !res.properties.lock_free {
             if access.is_shared() {
@@ -102,7 +102,6 @@ pub fn codegen(ctxt: Context, needs_lt: &mut bool, app: &App) -> (TokenStream2, 
 
     let doc = format!("Shared resources `{}` has access to", ctxt.ident(app));
     let ident = util::shared_resources_ident(ctxt, app);
-    let ident = util::mark_internal_ident(&ident);
     let item = quote!(
         #[allow(non_snake_case)]
         #[allow(non_camel_case_types)]

--- a/macros/src/codegen/software_tasks.rs
+++ b/macros/src/codegen/software_tasks.rs
@@ -37,7 +37,6 @@ pub fn codegen(
 
         // Create free queues and inputs / instants buffers
         let fq = util::fq_ident(name);
-        let fq = util::mark_internal_ident(&fq);
 
         let (fq_ty, fq_expr, mk_uninit): (_, _, Box<dyn Fn() -> Option<_>>) = {
             (
@@ -61,7 +60,6 @@ pub fn codegen(
 
         for (_, monotonic) in &app.monotonics {
             let instants = util::monotonic_instants_ident(name, &monotonic.ident);
-            let instants = util::mark_internal_ident(&instants);
             let mono_type = &monotonic.ty;
 
             let uninit = mk_uninit();
@@ -82,7 +80,6 @@ pub fn codegen(
 
         let uninit = mk_uninit();
         let inputs_ident = util::inputs_ident(name);
-        let inputs_ident = util::mark_internal_ident(&inputs_ident);
         mod_app.push(quote!(
             #uninit
             // /// Buffer that holds the inputs of a task

--- a/macros/src/codegen/timer_queue.rs
+++ b/macros/src/codegen/timer_queue.rs
@@ -10,7 +10,7 @@ pub fn codegen(app: &App, analysis: &Analysis, _extra: &Extra) -> Vec<TokenStrea
 
     if !app.monotonics.is_empty() {
         // Generate the marker counter used to track for `cancel` and `reschedule`
-        let tq_marker = util::mark_internal_ident(&util::timer_queue_marker_ident());
+        let tq_marker = util::timer_queue_marker_ident();
         items.push(quote!(
             // #[doc = #doc]
             #[doc(hidden)]
@@ -53,11 +53,9 @@ pub fn codegen(app: &App, analysis: &Analysis, _extra: &Extra) -> Vec<TokenStrea
     for (_, monotonic) in &app.monotonics {
         let monotonic_name = monotonic.ident.to_string();
         let tq = util::tq_ident(&monotonic_name);
-        let tq = util::mark_internal_ident(&tq);
         let t = util::schedule_t_ident();
         let mono_type = &monotonic.ty;
         let m_ident = util::monotonic_ident(&monotonic_name);
-        let m_ident = util::mark_internal_ident(&m_ident);
 
         // Static variables and resource proxy
         {
@@ -82,7 +80,6 @@ pub fn codegen(app: &App, analysis: &Analysis, _extra: &Extra) -> Vec<TokenStrea
             ));
 
             let mono = util::monotonic_ident(&monotonic_name);
-            let mono = util::mark_internal_ident(&mono);
             // For future use
             // let doc = &format!("Storage for {}", monotonic_name);
 
@@ -106,7 +103,6 @@ pub fn codegen(app: &App, analysis: &Analysis, _extra: &Extra) -> Vec<TokenStrea
                     let cfgs = &task.cfgs;
                     let priority = task.args.priority;
                     let rq = util::rq_ident(priority);
-                    let rq = util::mark_internal_ident(&rq);
                     let rqt = util::spawn_t_ident(priority);
 
                     // The interrupt that runs the task dispatcher


### PR DESCRIPTION
Refactor so that all `idents` that had to call `mark_ident_internal` before now call `mark_name_internal` in the `util` module by default.

The commits can (and probably should) be squashed, they're separated for clarity.

Fixes #512