### PR TITLE
Update README to highlight `cortex-m` 0.6 vs 0.7 new feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,6 @@ on:
       - master
       - staging
       - trying
-      - test
-      - v0.5.7-as-released
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This is just a general README update. I will open another PR for the rust-doc text in branch 0.5.x, in case there is a  new release of 0.5.x at some point.