### PR TITLE
v0.5: Remove cortex-m-rt dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ required-features = ["__v7"]
 [dependencies]
 cortex-m-rtic-macros = { path = "macros", version = "0.5.3" }
 rtic-core = "0.3.0"
-cortex-m-rt = "0.6.9"
 heapless = "0.6.1"
 
 [dependencies.cortex-m]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,6 @@ extern crate cortex_m_7 as cortex_m;
 use cortex_m::interrupt::InterruptNumber;
 
 use cortex_m::peripheral::{CBP, CPUID, DCB, DWT, FPB, FPU, ITM, MPU, NVIC, SCB, TPIU};
-#[cfg(all(not(feature = "heterogeneous"), not(feature = "homogeneous")))]
-use cortex_m_rt as _; // vector table
 pub use cortex_m_rtic_macros::app;
 pub use rtic_core::{Exclusive, Mutex};
 


### PR DESCRIPTION
It's not needed, since the user has to supply a PAC which will already depend on a suitable
cortex-m-rt version.

This allows using RTIC v0.5 with either cortex-m-rt 0.6 or 0.7.