### PR TITLE
Release 0.6.0-rc.3 due to breaking change in rtic-syntax naming of shared and local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -444,7 +444,17 @@ Yanked due to a soundness issue in `init`; the issue has been mostly fixed in v0
 
 - Initial release
 
-[Unreleased]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.9...HEAD
+[Unreleased]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.6.0-rc.3...HEAD
+[v0.6.0-rc.3]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.6.0-rc.2...v0.6.0-rc.3
+[v0.6.0-rc.2]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.6.0-rc.1...v0.6.0-rc.2
+[v0.6.0-rc.1]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.6.0-rc.0...v0.6.0-rc.1
+[v0.6.0-rc.0]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.6.0-alpha.5...v0.6.0-rc.0
+[v0.6.0-alpha.5]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.6.0-alpha.4...v0.6.0-alpha.5
+[v0.6.0-alpha.4]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.6.0-alpha.3...v0.6.0-alpha.4
+[v0.6.0-alpha.3]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.6.0-alpha.2...v0.6.0-alpha.3
+[v0.6.0-alpha.2]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.6.0-alpha.1...v0.6.0-alpha.2
+[v0.6.0-alpha.1]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.6.0-alpha.0...v0.6.0-alpha.1
+[v0.6.0-alpha.0]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.5...v0.6.0-alpha.0
 [v0.5.x unreleased]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.8...v0.5.x
 [v0.5.9]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.8...v0.5.9
 [v0.5.8]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.7...v0.5.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Match rtic-syntax Analysis-struct updates from https://github.com/rtic-rs/rtic-syntax/pull/61
+
 ## [v0.6.0-rc.2] - 2021-09-28
 
 - Fixed issue with `cortex_m` being used by the codegen instead of using the `rtic::export::...` which could make an app not compile if Systick is used and the user did not have the cortex-m crate as a dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+
+## [v0.6.0-rc.3] - 2021-11-08
+
 ### Fixed
 
 - Match rtic-syntax Analysis-struct updates from https://github.com/rtic-rs/rtic-syntax/pull/61
@@ -19,11 +22,25 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Monotonic handlers default to maximum priority instead of minimum (to follow RTIC 0.5)
 - Better support for `rust-analyzer`
 
+## [v0.5.9] - 2021-09-27
+
+- Removed the `cortex-m-rt` dependency
+- Docs updates
+
+## [v0.5.8] - 2021-08-19
+
+- Feature flag was added to support `cortex-m v0.7.x`
+- MSRV raised to 1.38.
+
 ## [v0.6.0-alpha.5] - 2021-07-09
 
 ### Changed
 
 - The new resources syntax is implemented.
+
+## [v0.5.7] - 2021-07-05
+
+- Backport: "you must enable the rt feature" compile time detection
 
 ## [v0.6.0-alpha.4] - 2021-05-27
 
@@ -59,6 +76,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support for multi-locks, see `examples/multilock.rs` for syntax.
 - New monotonic syntax and support, see `#[monotonic]`
+
+## [v0.5.6] - 2021-03-03
+
+- **Security** Use latest security patched heapless
 
 ## [v0.6.0-alpha.0] - 2020-11-14
 
@@ -423,7 +444,12 @@ Yanked due to a soundness issue in `init`; the issue has been mostly fixed in v0
 
 - Initial release
 
-[Unreleased]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.5...HEAD
+[Unreleased]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.9...HEAD
+[v0.5.x unreleased]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.8...v0.5.x
+[v0.5.9]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.8...v0.5.9
+[v0.5.8]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.7...v0.5.8
+[v0.5.7]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.6...v0.5.7
+[v0.5.6]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.5...v0.5.6
 [v0.5.5]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.4...v0.5.5
 [v0.5.4]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.3...v0.5.4
 [v0.5.3]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.2...v0.5.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,14 @@ name = "cortex-m-rtic"
 readme = "README.md"
 repository = "https://github.com/rtic-rs/cortex-m-rtic"
 
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 
 [lib]
 name = "rtic"
 
 [dependencies]
 cortex-m = "0.7.0"
-cortex-m-rtic-macros = { path = "macros", version = "0.6.0-rc.2" }
+cortex-m-rtic-macros = { path = "macros", version = "0.6.0-rc.3" }
 rtic-monotonic = "0.1.0-rc.1"
 rtic-core = "0.3.1"
 heapless = "0.7.7"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m-rtic-macros"
 readme = "../README.md"
 repository = "https://github.com/rtic-rs/cortex-m-rtic"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 
 [lib]
 proc-macro = true
@@ -22,4 +22,4 @@ proc-macro2 = "1"
 proc-macro-error = "1"
 quote = "1"
 syn = "1"
-rtic-syntax = "0.5.0-rc.1"
+rtic-syntax = "0.5.0-rc.2"

--- a/macros/src/codegen/post_init.rs
+++ b/macros/src/codegen/post_init.rs
@@ -14,7 +14,7 @@ pub fn codegen(app: &App, analysis: &Analysis) -> Vec<TokenStream2> {
         let mangled_name = util::static_shared_resource_ident(name);
         // If it's live
         let cfgs = res.cfgs.clone();
-        if analysis.shared_resource_locations.get(name).is_some() {
+        if analysis.shared_resources.get(name).is_some() {
             stmts.push(quote!(
                 // We include the cfgs
                 #(#cfgs)*
@@ -31,7 +31,7 @@ pub fn codegen(app: &App, analysis: &Analysis) -> Vec<TokenStream2> {
         let mangled_name = util::static_local_resource_ident(name);
         // If it's live
         let cfgs = res.cfgs.clone();
-        if analysis.local_resource_locations.get(name).is_some() {
+        if analysis.local_resources.get(name).is_some() {
             stmts.push(quote!(
                 // We include the cfgs
                 #(#cfgs)*


### PR DESCRIPTION
`rtic-syntax` got the old multicore concept of `Locations` removed, see https://github.com/rtic-rs/rtic-syntax/pull/61

This updates `cortex-m-rtic` to match this