### PR TITLE
Better errors on when missing to lock shared resources

### DIFF
--- a/macros/src/codegen/shared_resources.rs
+++ b/macros/src/codegen/shared_resources.rs
@@ -43,21 +43,23 @@ pub fn codegen(
         // For future use
         // let doc = format!(" RTIC internal: {}:{}", file!(), line!());
 
+        let shared_name = util::need_to_lock_ident(name);
+
         if !res.properties.lock_free {
             mod_resources.push(quote!(
                 // #[doc = #doc]
                 #[doc(hidden)]
                 #[allow(non_camel_case_types)]
                 #(#cfgs)*
-                pub struct #name<'a> {
+                pub struct #shared_name<'a> {
                     priority: &'a Priority,
                 }
 
                 #(#cfgs)*
-                impl<'a> #name<'a> {
+                impl<'a> #shared_name<'a> {
                     #[inline(always)]
                     pub unsafe fn new(priority: &'a Priority) -> Self {
-                        #name { priority }
+                        #shared_name { priority }
                     }
 
                     #[inline(always)]
@@ -86,7 +88,7 @@ pub fn codegen(
                 extra,
                 cfgs,
                 true,
-                &name,
+                &shared_name,
                 quote!(#ty),
                 ceiling,
                 ptr,

--- a/macros/src/codegen/shared_resources_struct.rs
+++ b/macros/src/codegen/shared_resources_struct.rs
@@ -33,6 +33,7 @@ pub fn codegen(ctxt: Context, needs_lt: &mut bool, app: &App) -> (TokenStream2, 
         };
         let ty = &res.ty;
         let mangled_name = util::static_shared_resource_ident(&name);
+        let shared_name = util::need_to_lock_ident(name);
 
         if !res.properties.lock_free {
             if access.is_shared() {
@@ -48,12 +49,12 @@ pub fn codegen(ctxt: Context, needs_lt: &mut bool, app: &App) -> (TokenStream2, 
 
                 fields.push(quote!(
                     #(#cfgs)*
-                    pub #name: shared_resources::#name<'a>
+                    pub #name: shared_resources::#shared_name<'a>
                 ));
 
                 values.push(quote!(
                     #(#cfgs)*
-                    #name: shared_resources::#name::new(priority)
+                    #name: shared_resources::#shared_name::new(priority)
 
                 ));
 

--- a/macros/src/codegen/util.rs
+++ b/macros/src/codegen/util.rs
@@ -268,6 +268,13 @@ pub fn declared_static_local_resource_ident(name: &Ident, task_name: &Ident) -> 
     ))
 }
 
+pub fn need_to_lock_ident(name: &Ident) -> Ident {
+    Ident::new(
+        &format!("{}_that_needs_to_be_locked", name.to_string()),
+        name.span(),
+    )
+}
+
 /// The name to get better RT flag errors
 pub fn rt_err_ident() -> Ident {
     Ident::new(


### PR DESCRIPTION
Old error:

```
error[E0614]: type `value<'_>` cannot be dereferenced
  --> examples/lock_minimal.rs:33:9
   |
33 |         *c.shared.value += 1;
   |         ^^^^^^^^^^^^^^^

```

New error:

```
error[E0614]: type `value_that_needs_to_be_locked<'_>` cannot be dereferenced
  --> examples/lock_minimal.rs:33:9
   |
33 |         *c.shared.value += 1;
   |         ^^^^^^^^^^^^^^^

```