### PR TITLE
Highlight how to run examples locally

### DIFF
--- a/book/en/src/by-example.md
+++ b/book/en/src/by-example.md
@@ -15,3 +15,18 @@ Check [the embedded Rust book] for instructions on how to set up an
 embedded development environment that includes QEMU.
 
 [the embedded Rust book]: https://rust-embedded.github.io/book/intro/install.html
+
+To run the examples found in `examples/` locally, cargo needs a supported `target` and
+either `--examples` (run all examples) or `--example NAME` to run a specific example.
+
+Assuming dependencies in place, running:
+
+``` console
+$ cargo run --target thumbv7m-none-eabi --example locals
+```
+
+Yields this output:
+
+``` console
+{{#include ../../../ci/expected/locals.run}}
+```

--- a/book/en/src/by-example/resources.md
+++ b/book/en/src/by-example/resources.md
@@ -37,6 +37,8 @@ The example application shown below contains two tasks where each task has acces
 {{#include ../../../../examples/locals.rs}}
 ```
 
+Running the example:
+
 ``` console
 $ cargo run --target thumbv7m-none-eabi --example locals
 {{#include ../../../../ci/expected/locals.run}}


### PR DESCRIPTION
How examples are run never gets properly introduced before used in `by-example/resources.md`

Fixes #587 