### PR TITLE
RTIC macro expansion: Try to find target-dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Try to detect `target-dir` for rtic-expansion.rs
 - Bump RTIC dependencies also updated to v1.0.0
 - Edition 2021
 - Change default `idle` behaviour to be `NOP` instead of `WFI`

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -23,3 +23,6 @@ proc-macro-error = "1"
 quote = "1"
 syn = "1"
 rtic-syntax = "1.0.0"
+
+[features]
+debugprint = []

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -7,7 +7,7 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
-use std::{fs, path::Path};
+use std::{env, fs, path::Path};
 
 use rtic_syntax::Settings;
 
@@ -42,9 +42,69 @@ pub fn app(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let ts = codegen::app(&app, &analysis, &extra);
 
+    // Default output path: <project_dir>/target/
+    let mut out_dir = Path::new("target");
+
+    // Get output directory from Cargo environment
+    // TODO don't want to break builds if OUT_DIR is not set, is this ever the case?
+    let out_str = env::var("OUT_DIR").unwrap_or_else(|_| "".to_string());
+
+    // Assuming we are building for a thumbv* target
+    let target_triple_prefix = "thumbv";
+
+    // Check for special scenario where default target/ directory is not present
+    //
+    // This is configurable in .cargo/config:
+    //
+    // [build]
+    // target-dir = "target"
+    #[cfg(feature = "debugprint")]
+    println!("OUT_DIR\n{:#?}", out_str);
+
+    if !out_dir.exists() {
+        // Set out_dir to OUT_DIR
+        out_dir = Path::new(&out_str);
+
+        // Default build path, annotated below:
+        // $(pwd)/target/thumbv7em-none-eabihf/debug/build/cortex-m-rtic-<HASH>/out/
+        // <project_dir>/<target-dir>/<TARGET>/debug/build/cortex-m-rtic-<HASH>/out/
+        //
+        // traverse up to first occurrence of TARGET, approximated with starts_with("thumbv")
+        // and use the parent() of this path
+        //
+        // If no "target" directory is found, <project_dir>/<out_dir_root> is used
+        for path in out_dir.ancestors() {
+            if let Some(dir) = path.components().last() {
+                if dir
+                    .as_os_str()
+                    .to_str()
+                    .unwrap()
+                    .starts_with(target_triple_prefix)
+                //|| path.ends_with(&out_dir_root)
+                {
+                    if let Some(out) = path.parent() {
+                        out_dir = out;
+                        #[cfg(feature = "debugprint")]
+                        println!("{:#?}\n", out_dir);
+                        break;
+                    } else {
+                        // If no parent, just use it
+                        out_dir = path;
+                        break;
+                    }
+                }
+            }
+        }
+    } else {
+        #[cfg(feature = "debugprint")]
+        println!("\ntarget/ exists\n");
+    }
+
     // Try to write the expanded code to disk
-    if Path::new("target").exists() {
-        fs::write("target/rtic-expansion.rs", ts.to_string()).ok();
+    if let Some(out_str) = out_dir.to_str() {
+        #[cfg(feature = "debugprint")]
+        println!("Write file:\n{}/rtic-expansion.rs\n", out_str);
+        fs::write(format!("{}/rtic-expansion.rs", out_str), ts.to_string()).ok();
     }
 
     ts.into()


### PR DESCRIPTION
Seems over-engineered, but for projects where 

```
[build]
target-dir = "target"
```
is set to anything other than default `target` RTIC did simply not produce any `rtic-expansion.rs`.

This changes the approach to not giving up if not finding `target/` by looking at `OUT_DIR` and traversing back until `TARGET` is found.

As the `TARGET` target-triple variable is not available, approximate the `TARGET` folder (found in `target-dir`) with `s.starts_with("thumbv")`.

`target-dir` as set in `.cargo/config` will now be the parent directory of the `Path` ending with `TARGET`

## Example running with default target:
```
cortex-m-rtic on  expansionoutdir [$!?] is 📦 v1.0.0 via R v1.58.0 took 4s
❯ cargo build --example spawn --target thumbv7em-none-eabihf
OUT_DIR
"/home/henrik/rust/rtic/cortex-m-rtic/target/thumbv7em-none-eabihf/debug/build/cortex-m-rtic-5bd81e8412a790d5/out"

target/ exists

Write file:
target/rtic-expansion.rs

    Finished dev [unoptimized + debuginfo] target(s) in 7.20s

```

## Contrived example
With `.cargo/config` containing:

```
[build]
target-dir = "/tmp/cargothingy/../rust/./target/cargo"`
```

```
cortex-m-rtic on  expansionoutdir [$!?] is 📦 v1.0.0 via R v1.58.0 took 3s
❯ cargo build --example spawn --target thumbv7em-none-eabihf
OUT_DIR
"/tmp/cargothingy/../rust/./target/cargo/thumbv7em-none-eabihf/debug/build/cortex-m-rtic-5bd81e8412a790d5/out"
"/tmp/cargothingy/../rust/./target/cargo"

Write file:
/tmp/cargothingy/../rust/./target/cargo/rtic-expansion.rs

    Finished dev [unoptimized + debuginfo] target(s) in 6.42s

```

## Less extreme with relative paths
```
[build]
target-dir = "../../cargothingy/target/buildfiles/and-stuff"
```

```
OUT_DIR
"/home/henrik/rust/rtic/cortex-m-rtic/../../cargothingy/target/buildfiles/and-stuff/thumbv7em-none-eabihf/debug/build/cortex-m-rtic-5bd81e8412a790d5/out"
"/home/henrik/rust/rtic/cortex-m-rtic/../../cargothingy/target/buildfiles/and-stuff"

Write file:
/home/henrik/rust/rtic/cortex-m-rtic/../../cargothingy/target/buildfiles/and-stuff/rtic-expansion.rs

    Finished dev [unoptimized + debuginfo] target(s) in 6.78s

```

Note: If the user creates a folder named target in the same directory where `Cargo.toml`/crate root is, that will be used for storing the expansion.

```
<...>
OUT_DIR
"/home/henrik/rust/rtic/cortex-m-rtic/../../cargothingy/target/buildfiles/and-stuff/thumbv7em-none-eabihf/debug/build/cortex-m-rtic-5bd81e8412a790d5/out"

target/ exists

Write file:
target/rtic-expansion.rs

    Finished dev [unoptimized + debuginfo] target(s) in 6.62s
```
