### PR TITLE
Update tips_monotonic_impl.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - CI changelog entry enforcer
 - `examples/periodic-at.rs`, an example of a periodic timer without accumulated drift.
 - `examples/periodic-at2.rs`, an example of a periodic process with two tasks, with offset timing. Here we depict two alternative usages of the timer type, explicit and trait based.
+- book: Update `Monotonic` tips.
 
 ## [v1.0.0] - 2021-12-25
 

--- a/book/en/src/by-example/tips_monotonic_impl.md
+++ b/book/en/src/by-example/tips_monotonic_impl.md
@@ -9,10 +9,10 @@ Implementing time counting that supports large time spans is generally **difficu
 implementing time handling was a common problem.
 Moreover, the relation between time and timers used for scheduling was difficult to understand.
 
-For RTIC 0.6 we instead assume the user has a time library, e.g. [`fugit`] or [`embedded_time`],
+For RTIC 1.0 we instead assume the user has a time library, e.g. [`fugit`] or [`embedded_time`],
 as the basis for all time-based operations when implementing `Monotonic`.
-This makes it almost trivial to implement the `Monotonic` trait allowing the use of any timer in
-the system for scheduling.
+This makes it much easier to correctly implement the `Monotonic` trait allowing the use of
+almost any timer in the system for scheduling.
 
 The trait documents the requirements for each method,
 and for inspiration here is a list of `Monotonic` implementations:
@@ -20,8 +20,8 @@ and for inspiration here is a list of `Monotonic` implementations:
 - [`STM32F411 series`], implemented for the 32-bit timers
 - [`Nordic nRF52 series Timer`], implemented for the 32-bit timers
 - [`Nordic nRF52 series RTC`], implemented for the RTCs
-- [`Systick based`], runs at a fixed rate - some overhead but simple
-- [`DWT and Systick based`], a more efficient `Systick` based implementation, but requires `DWT`
+- [`Systick based`], runs at a fixed interrupt (tick) rate - with some overhead but simple and with support for large time spans
+- [`DWT and Systick based`], a more efficient (tickless) implementation - requires both `SysTick` and `DWT`, supports both high resolution and large time spans
 
 If you know of more implementations feel free to add them to this list.
 

--- a/book/en/src/by-example/tips_monotonic_impl.md
+++ b/book/en/src/by-example/tips_monotonic_impl.md
@@ -28,8 +28,8 @@ If you know of more implementations feel free to add them to this list.
 [`rtic_monotonic::Monotonic`]: https://docs.rs/rtic-monotonic/
 [`fugit`]: https://docs.rs/fugit/
 [`embedded_time`]: https://docs.rs/embedded_time/
-[`STM32F411 series`]: https://github.com/kalkyl/f411-rtic/blob/main/src/bin/mono.rs
-[`Nordic nRF52 series Timer`]: https://github.com/kalkyl/nrf-play/blob/main/src/bin/mono.rs
+[`STM32F411 series`]: https://github.com/kalkyl/f411-rtic/blob/a696fce7d6d19fda2356c37642c4d53547982cca/src/mono.rs
+[`Nordic nRF52 series Timer`]: https://github.com/kalkyl/nrf-play/blob/47f4410d4e39374c18ff58dc17c25159085fb526/src/mono.rs
 [`Nordic nRF52 series RTC`]: https://gist.github.com/korken89/fe94a475726414dd1bce031c76adc3dd
 [`Systick based`]: https://github.com/rtic-rs/systick-monotonic
 [`DWT and Systick based`]: https://github.com/rtic-rs/dwt-systick-monotonic


### PR DESCRIPTION
* There is no RTIC 0.6, only several RCs.
* Timers without interrupts (like the DWT cycle counter alone) will not be useful for `Monotonic` impls.
* Clarified some of the descriptions of the various implementations.

Close #597 
Close #594