### PR TITLE
GHA: Automatic merge to release/vX

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -479,8 +479,18 @@ jobs:
           sed "s|URL|$stable|g" redirect.html > $td/index.html
 
           # Create the redirects for dev-version
-          sed 's|URL|rtic/index.html|g' redirect.html > $td/$devver/api/index.html
-          sed 's|URL|book/en|g' redirect.html > $td/$devver/index.html
+          # If the current stable and the version being built differ,
+          # then there is a dev-version and the links should point to it.
+          if [[ "$stable" != "{{ env.versionmajor }}" ]];
+          then
+            sed 's|URL|rtic/index.html|g' redirect.html > $td/$devver/api/index.html
+            sed 's|URL|book/en|g' redirect.html > $td/$devver/index.html
+          else
+            # If the current stable and the "dev" version in master branch
+            # share the same major version, redirect dev/ to stable book
+            sed 's|URL|rtic.rs/$stable/api/rtic|g' redirect.html > $td/$devver/api/index.html
+            sed 's|URL|rtic.rs/$stable|g' redirect.html > $td/$devver/index.html
+          fi
 
           # Build books
           for lang in ${langs[@]}; do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -363,9 +363,11 @@ jobs:
           linkchecker $td/book/en/
           linkchecker $td/book/ru/
 
-  # Only runs when pushing to master branch
-  deploy:
-    name: deploy
+  # Update stable branch
+  #
+  # This needs to run before book is built
+  mergetostablebranch:
+    name: If CI passes, merge master branch into release/vX
     runs-on: ubuntu-20.04
     needs:
       - style
@@ -378,6 +380,39 @@ jobs:
       - tests
       - docs
       - mdbook
+
+    # Only run this when pushing to master branch
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get crate version and print output branch release/vX
+        id: crateversionbranch
+        # Parse metadata for version number, extract the Semver Major
+        run: |
+          VERSION=$(cargo metadata --format-version 1 --no-deps --offline | jq -r '.packages[] | select(.name =="cortex-m-rtic") | .version')
+          VERSIONMAJOR=${VERSION%.*.*}
+          echo "branch=release/v$VERSIONMAJOR" >> $GITHUB_ENV
+          echo "versionmajor=$VERSIONMAJOR" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_ENV
+
+      - uses: everlytic/branch-merge@1.1.2
+        with:
+          github_token: ${{ github.token }}
+          source_ref: 'master'
+          target_branch: ${{ env.branch }}
+          commit_message_template: '[Bors] Merged {source_ref} into target {target_branch}'
+
+  # Only runs when pushing to master branch
+  # Bors run CI against staging branch,
+  # if that succeeds Borst tries against master branch
+  # If all tests pass, then deploy stage is run
+  deploy:
+    name: deploy
+    runs-on: ubuntu-20.04
+    needs:
+      mergetostablebranch
+
     # Only run this when pushing to master branch
     if: github.ref == 'refs/heads/master'
     steps:
@@ -400,6 +435,16 @@ jobs:
         with:
           mdbook-version: 'latest'
 
+      - name: Get crate version
+        id: crateversion
+        # Parse metadata for version number, extract the Semver Major
+        run: |
+          VERSION=$(cargo metadata --format-version 1 --no-deps --offline | jq -r '.packages[] | select(.name =="cortex-m-rtic") | .version')
+          VERSIONMAJOR=${VERSION%.*.*}
+          echo "branch=release/v$VERSIONMAJOR" >> $GITHUB_ENV
+          echo "versionmajor=$VERSIONMAJOR" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_ENV
+
       - name: Remove cargo-config
         run: rm -f .cargo/config
 
@@ -412,12 +457,12 @@ jobs:
           langs=( en ru )
           devver=( dev )
           # The latest stable must be the first element in the array
-          vers=( 1.0.x 0.5.x 0.4.x  )
+          vers=( "1" "0.5" "0.4"  )
 
           # All releases start with "v"
           # followed by MAJOR.MINOR.PATCH, see semver.org
-          # Retain MAJOR.MINOR as $stable
-          stable=${vers%.*}
+          # Store first in array as stable
+          stable=${vers}
 
           echo "Stable version: $stable"
 
@@ -449,11 +494,11 @@ jobs:
           # Build older versions, including stable
           root=$(pwd)
           for ver in ${vers[@]}; do
-              prefix=${ver%.*}
+              prefix=${ver}
 
               mkdir -p $td/$prefix/book
               src=$(mktemp -d)
-              curl -L https://github.com/rtic-rs/cortex-m-rtic/archive/v${ver}.tar.gz | tar xz --strip-components 1 -C $src
+              curl -L https://github.com/rtic-rs/cortex-m-rtic/archive/release/v${ver}.tar.gz | tar xz --strip-components 1 -C $src
 
               pushd $src
               rm -f .cargo/config

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -370,6 +370,7 @@ jobs:
     needs:
       - style
       - check
+      - clippy
       - checkexamples
       - testexamples
       - checkmacros

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- If current $stable and master version matches, dev-book redirects to $stable book
+- During deploy stage, merge master branch into current stable IFF cargo package version matches
+- Rework branch structure, release/vVERSION
 - Cargo clippy in CI
 - Use rust-cache Github Action
 - CI changelog entry enforcer


### PR DESCRIPTION
- Require clippy for deploy
- GHA: Automatic merge to release/vX
- Link dev-book to stable if they are describe the same release
- Update CHANGELOG

Development work is done in the master branch

Older versions previously were found in v0.5.x, v0.4.x branches.
Now with v1 released, and any breaking change forcing a v2,
a need to streamline documentation building arose.

The different docs:

- rtic.rs
  - latest stable (v1)
    - API documentation
    - RTIC book
  - old stable (v0.5)
    - API documentation
    - RTIC book
  - oldold stable (v0.4)
    - API documentation
    - RTIC book

- docs.rs
  - all previous crates.io releases
    - API documentation

With this PR, when a pull request gets merged to master
with CI passing the current master branch gets merged
to `release/v$VERSION` where `$VERSION` is parsed from
cargo metadata of cortex-m-rtic.

The deployment of docs GHA job is dependent on this merge job,
and therefore the docs published to rtic.rs will contain the latest
content from the merged PR.

Assuming the current situation where `v1` is the latest stable,
a PR should trigger a merge to `release/v1` and then docs gets pushed
to `gh-pages` branch (rtic.rs).

For the future, when the latest stable is still `v1`, but the current
dev version in `master` branch is `v2` the GHA job will push to `release/v2` (dev branch).

For the future we might decide if this push of the dev branch is desirable.

If the current stable version and dev version share the same major version,
the dev book redirection on rtic.rs will point to the stable book instead.
