### PR TITLE
Allow naming lock type of shared resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `examples/periodic-at.rs`, an example of a periodic timer without accumulated drift.
 - `examples/periodic-at2.rs`, an example of a periodic process with two tasks, with offset timing. Here we depict two alternative usages of the timer type, explicit and trait based.
 - book: Update `Monotonic` tips.
+- rename lock types `{}_lock` (instead of `{}_that_needs_to_be_locked`)
+- change visibility of `app::shared_resources` module to pub
 
 ### Fixed
 

--- a/macros/src/codegen/shared_resources.rs
+++ b/macros/src/codegen/shared_resources.rs
@@ -43,7 +43,7 @@ pub fn codegen(
         // For future use
         // let doc = format!(" RTIC internal: {}:{}", file!(), line!());
 
-        let shared_name = util::need_to_lock_ident(name);
+        let shared_name = util::lock_ident(name);
 
         if !res.properties.lock_free {
             mod_resources.push(quote!(

--- a/macros/src/codegen/shared_resources.rs
+++ b/macros/src/codegen/shared_resources.rs
@@ -99,7 +99,7 @@ pub fn codegen(
     let mod_resources = if mod_resources.is_empty() {
         quote!()
     } else {
-        quote!(mod shared_resources {
+        quote!(pub mod shared_resources {
             use rtic::export::Priority;
 
             #(#mod_resources)*

--- a/macros/src/codegen/shared_resources_struct.rs
+++ b/macros/src/codegen/shared_resources_struct.rs
@@ -33,7 +33,7 @@ pub fn codegen(ctxt: Context, needs_lt: &mut bool, app: &App) -> (TokenStream2, 
         };
         let ty = &res.ty;
         let mangled_name = util::static_shared_resource_ident(name);
-        let shared_name = util::need_to_lock_ident(name);
+        let shared_name = util::lock_ident(name);
 
         if !res.properties.lock_free {
             if access.is_shared() {

--- a/macros/src/codegen/util.rs
+++ b/macros/src/codegen/util.rs
@@ -259,8 +259,8 @@ pub fn declared_static_local_resource_ident(name: &Ident, task_name: &Ident) -> 
     mark_internal_name(&format!("local_{}_{}", task_name, name))
 }
 
-pub fn need_to_lock_ident(name: &Ident) -> Ident {
-    Ident::new(&format!("{}_that_needs_to_be_locked", name), name.span())
+pub fn lock_ident(name: &Ident) -> Ident {
+    Ident::new(&format!("{}_lock", name), name.span())
 }
 
 /// The name to get better RT flag errors


### PR DESCRIPTION
This PR allows users to name the lock types of shared resources. This is useful to pass the locks to other functions.
It's not always possible to just specify the argument type as `impl rtic::Mutex<Resource>`, because the function then is no longer trait object safe. The type can now be named as `app::shared_resources::{}_lock`.

Example:
This trait is now object safe!
```rust
trait TraitObject {
  fn func(
    &self,
    lock: &mut app::shared_resources::resource_lock,
  );
}

```

changes:

- change lock type ident: `{}_that_needs_to_be_locked` => `{}_lock`
- change visibility of `shared_resources` module to pub

closes #611