### PR TITLE
rtic::mutex::prelude::* fixes glob import lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Re-export `rtic_core::prelude` as `rtic::mutex::prelude` to allow glob imports + Clippy
 - Fix dated migration docs for spawn
 - Force mdBook to return error codes
 - Readded missing ramfunc output to book

--- a/macros/src/codegen/hardware_tasks.rs
+++ b/macros/src/codegen/hardware_tasks.rs
@@ -97,7 +97,7 @@ pub fn codegen(
                 #[allow(non_snake_case)]
                 fn #name(#context: #name::Context) {
                     use rtic::Mutex as _;
-                    use rtic::mutex_prelude::*;
+                    use rtic::mutex::prelude::*;
 
                     #(#stmts)*
                 }

--- a/macros/src/codegen/idle.rs
+++ b/macros/src/codegen/idle.rs
@@ -68,7 +68,7 @@ pub fn codegen(
             #[allow(non_snake_case)]
             fn #name(#context: #name::Context) -> ! {
                 use rtic::Mutex as _;
-                use rtic::mutex_prelude::*;
+                use rtic::mutex::prelude::*;
 
                 #(#stmts)*
             }

--- a/macros/src/codegen/software_tasks.rs
+++ b/macros/src/codegen/software_tasks.rs
@@ -131,7 +131,7 @@ pub fn codegen(
                 #[allow(non_snake_case)]
                 fn #name(#context: #name::Context #(,#inputs)*) {
                     use rtic::Mutex as _;
-                    use rtic::mutex_prelude::*;
+                    use rtic::mutex::prelude::*;
 
                     #(#stmts)*
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,11 @@ pub use cortex_m_rtic_macros::app;
 pub use rtic_core::{prelude as mutex_prelude, Exclusive, Mutex};
 pub use rtic_monotonic::{self, Monotonic};
 
+/// module `mutex::prelude` provides `Mutex` and multi-lock variants. Recommended over `mutex_prelude`
+pub mod mutex {
+    pub use rtic_core::prelude;
+}
+
 #[doc(hidden)]
 pub mod export;
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub use rtic_monotonic::{self, Monotonic};
 /// module `mutex::prelude` provides `Mutex` and multi-lock variants. Recommended over `mutex_prelude`
 pub mod mutex {
     pub use rtic_core::prelude;
+    pub use rtic_core::Mutex;
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
Running cargo Clippy with pedantic rules denied

```
cargo clippy -- --deny clippy::pedantic
```

it will complain:

```
error: usage of wildcard import
   |
16 | use rtic::mutex_prelude::*;
   |     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `rtic::mutex_prelude::{Mutex, TupleExt01, TupleExt02, TupleExt03, TupleExt04, TupleExt05, TupleExt06, TupleExt07, TupleExt08, TupleExt09, TupleExt10, TupleExt11, TupleExt12, TupleExt13, TupleExt14, TupleExt15, TupleExt16, TupleExt17, TupleExt18, TupleExt19, TupleExt20, TupleExt21, TupleExt22, TupleExt23, TupleExt24, TupleExt25, TupleExt26, TupleExt27, TupleExt28, TupleExt29, TupleExt30, TupleExt31, TupleExt32}`
   |
   = note: `-D clippy::wildcard-imports` implied by `-D clippy::pedantic`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_imports

error: could not compile --- due to previous error
Error: command `cargo clippy -- --deny clippy::all --deny clippy::pedantic` failed, exit status: 101

```

Looking at the Clippy [wildcard-imports rule](https://rust-lang.github.io/rust-clippy/master/#wildcard_imports)
the exception is for wildcards on modules named prelude. Thus, `prelude::*` is OK.

Current state: `use rtic-core::prelude as mutex_prelude` almost fits the bill, but `mutex_prelude != prelude`.

As this was part of user facing API I don’t think we can remove the current setup,
so rtic-core `Mutex`, `Exclusive` and multi-lock `TupleExt0X` retained in
old location to be backwards compatible.
