### PR TITLE
Bump rtic-syntax to v1.0.2 and fix Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,34 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Changed
 
+## [v1.1.5] - 2022-06-23
+
+### Added
+
+### Fixed
+Bump rtic-syntax to 1.0.2
+fix ci: use SYST::PTR
+
+### Changed
+
+## [v1.1.4] - 2022-05-24
+
+### Added
+
+### Fixed
+Fix macros to Rust 2021
+
+### Changed
+
+## [v1.1.3] - 2022-05-24
+
+### Added
+
+### Fixed
+Fix clash with defmt
+
+### Changed
+
 ## [v1.1.2] - 2022-05-09
 
 ### Added
@@ -513,7 +541,10 @@ Yanked due to a soundness issue in `init`; the issue has been mostly fixed in v0
 
 - Initial release
 
-[Unreleased]: https://github.com/rtic-rs/cortex-m-rtic/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/rtic-rs/cortex-m-rtic/compare/v1.1.5...HEAD
+[v1.1.5]: https://github.com/rtic-rs/cortex-m-rtic/compare/v1.0.4...v1.1.5
+[v1.1.4]: https://github.com/rtic-rs/cortex-m-rtic/compare/v1.0.3...v1.1.4
+[v1.1.3]: https://github.com/rtic-rs/cortex-m-rtic/compare/v1.0.2...v1.1.3
 [v1.1.2]: https://github.com/rtic-rs/cortex-m-rtic/compare/v1.0.1...v1.1.2
 [v1.1.1]: https://github.com/rtic-rs/cortex-m-rtic/compare/v1.1.0...v1.1.1
 [v1.1.0]: https://github.com/rtic-rs/cortex-m-rtic/compare/v1.0.0...v1.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "rtic"
 
 [dependencies]
 cortex-m = "0.7.0"
-cortex-m-rtic-macros = { path = "macros", version = "1.1.1" }
+cortex-m-rtic-macros = { path = "macros", version = "1.1.5" }
 rtic-monotonic = "1.0.0"
 rtic-core = "1.0.0"
 heapless = "0.7.7"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m-rtic-macros"
 readme = "../README.md"
 repository = "https://github.com/rtic-rs/cortex-m-rtic"
-version = "1.1.4"
+version = "1.1.5"
 
 [lib]
 proc-macro = true
@@ -22,7 +22,7 @@ proc-macro2 = "1"
 proc-macro-error = "1"
 quote = "1"
 syn = "1"
-rtic-syntax = "1.0.1"
+rtic-syntax = "1.0.2"
 
 [features]
 debugprint = []


### PR DESCRIPTION
Use the latest rtic-syntax, update the changelog with the last few undocumented releases
