### PR TITLE
Remove use of basepri register on thumbv8m.base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Fixed
 
+- Distinguish between thumbv8m.base and thumbv8m.main for basepri usage.
+
 ### Changed
 
 ## [v1.1.3] - 2022-06-23

--- a/build.rs
+++ b/build.rs
@@ -7,15 +7,21 @@ fn main() {
         println!("cargo:rustc-cfg=rustc_is_nightly");
     }
 
-    if target.starts_with("thumbv6m") {
-        println!("cargo:rustc-cfg=armv6m");
-    }
-
+    // These targets all have know support for the BASEPRI register.
     if target.starts_with("thumbv7m")
         | target.starts_with("thumbv7em")
-        | target.starts_with("thumbv8m")
+        | target.starts_with("thumbv8m.main")
     {
-        println!("cargo:rustc-cfg=armv7m");
+        println!("cargo:rustc-cfg=have_basepri");
+
+    // These targets are all known to _not_ have the BASEPRI register.
+    } else if target.starts_with("thumb")
+        && !(target.starts_with("thumbv6m") | target.starts_with("thumbv8m.base"))
+    {
+        panic!(
+            "Unknown target '{}'. Need to update BASEPRI logic in build.rs.",
+            target
+        );
     }
 
     println!("cargo:rerun-if-changed=build.rs");

--- a/macros/src/codegen/util.rs
+++ b/macros/src/codegen/util.rs
@@ -253,6 +253,11 @@ pub fn static_shared_resource_ident(name: &Ident) -> Ident {
     mark_internal_name(&format!("shared_resource_{}", name))
 }
 
+/// Generates an Ident for the number of 32 bit chunks used for Mask storage.
+pub fn priority_mask_chunks_ident() -> Ident {
+    mark_internal_name("MASK_CHUNKS")
+}
+
 pub fn priority_masks_ident() -> Ident {
     mark_internal_name("MASKS")
 }


### PR DESCRIPTION
The basepri register appears to be aviable on thumbv8m.main but not thumbv8m.base. At the very least, attempting to compile against a Cortex-M23 based Microchip ATSAML10E16A generates an error:

```
error[E0432]: unresolved import `cortex_m::register::basepri`
  --> /Users/dwatson/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rtic-1.1.3/src/export.rs:25:5
   |
25 | use cortex_m::register::basepri;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `basepri` in `register`
```

I wasn't sure if it made more sense to replace the `armv7m` config flag with something related to basepri availability or to get closer to matching the cortex-m use of several architecture specific flags. In the end i chose to make the minimal change possible and just narrowed the existing `thumbv8m` check.

Context:
[cortex-m:src/register/mod.rs](https://github.com/rust-embedded/cortex-m/blob/4e908625204a1e95dd3fd5bdcd8d66d6bc11c3bc/src/register/mod.rs#L33):
```
#[cfg(all(not(armv6m), not(armv8m_base)))]
pub mod basepri;
```

[cortex-m:build.rs](https://github.com/rust-embedded/cortex-m/blob/4e908625204a1e95dd3fd5bdcd8d66d6bc11c3bc/build.rs#L21):
```
    } else if target.starts_with("thumbv8m.base") {
        println!("cargo:rustc-cfg=cortex_m");
        println!("cargo:rustc-cfg=armv8m");
        println!("cargo:rustc-cfg=armv8m_base");
```