### PR TITLE
Allow custom `link_section` attributes for late resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Added
 
+- Allow custom `link_section` attributes for late resources
+
 ### Fixed
 
 ### Changed

--- a/macros/src/codegen/local_resources.rs
+++ b/macros/src/codegen/local_resources.rs
@@ -27,8 +27,15 @@ pub fn codegen(
         let mangled_name = util::static_local_resource_ident(name);
 
         let attrs = &res.attrs;
+
         // late resources in `util::link_section_uninit`
-        let section = util::link_section_uninit();
+        // unless user specifies custom link section
+        let section = if attrs.iter().any(|attr| attr.path.is_ident("link_section")) {
+            None
+        }
+        else {
+            Some(util::link_section_uninit())
+        };
 
         // For future use
         // let doc = format!(" RTIC internal: {}:{}", file!(), line!());

--- a/macros/src/codegen/local_resources.rs
+++ b/macros/src/codegen/local_resources.rs
@@ -32,8 +32,7 @@ pub fn codegen(
         // unless user specifies custom link section
         let section = if attrs.iter().any(|attr| attr.path.is_ident("link_section")) {
             None
-        }
-        else {
+        } else {
             Some(util::link_section_uninit())
         };
 

--- a/macros/src/codegen/shared_resources.rs
+++ b/macros/src/codegen/shared_resources.rs
@@ -23,9 +23,16 @@ pub fn codegen(
         let ty = &res.ty;
         let mangled_name = &util::static_shared_resource_ident(name);
 
-        // late resources in `util::link_section_uninit`
-        let section = util::link_section_uninit();
         let attrs = &res.attrs;
+
+        // late resources in `util::link_section_uninit`
+        // unless user specifies custom link section
+        let section = if attrs.iter().any(|attr| attr.path.is_ident("link_section")) {
+            None
+        }
+        else {
+            Some(util::link_section_uninit())
+        };
 
         // For future use
         // let doc = format!(" RTIC internal: {}:{}", file!(), line!());

--- a/macros/src/codegen/shared_resources.rs
+++ b/macros/src/codegen/shared_resources.rs
@@ -29,8 +29,7 @@ pub fn codegen(
         // unless user specifies custom link section
         let section = if attrs.iter().any(|attr| attr.path.is_ident("link_section")) {
             None
-        }
-        else {
+        } else {
             Some(util::link_section_uninit())
         };
 


### PR DESCRIPTION
This commit makes RTIC aware of user-provided `link_section` attributes,
letting user override default section mapping.