### PR TITLE
CI: Run rustup and cargo directly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         run: sed -i 's,//deny_warnings_placeholder_for_ci,#![deny(warnings)],' src/lib.rs macros/src/lib.rs
 
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: cargo check
         run: cargo check --target=${{ matrix.target }}
@@ -75,7 +75,7 @@ jobs:
         run: sed -i 's,//deny_warnings_placeholder_for_ci,#![deny(warnings)],' src/lib.rs macros/src/lib.rs
 
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: cargo clippy
         run: clippy
@@ -107,7 +107,7 @@ jobs:
         run: rustup component add llvm-tools-preview
 
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Check the examples
         run: cargo check --examples --target=${{ matrix.target }}
@@ -143,7 +143,7 @@ jobs:
         run: cargo install cargo-binutils
 
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Install QEMU
         run: |
@@ -179,7 +179,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Fail on warnings
         run: sed -i 's,//deny_warnings_placeholder_for_ci,#![deny(warnings)],' src/lib.rs macros/src/lib.rs
@@ -196,7 +196,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Fail on warnings
         run: sed -i 's,//deny_warnings_placeholder_for_ci,#![deny(warnings)],' src/lib.rs macros/src/lib.rs
@@ -213,7 +213,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Fail on warnings
         run: sed -i 's,//deny_warnings_placeholder_for_ci,#![deny(warnings)],' src/lib.rs macros/src/lib.rs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: cargo clippy
-        run: clippy
+        run: cargo clippy
 
   # Verify all examples, checks
   checkexamples:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Fail on warnings
         run: sed -i 's,//deny_warnings_placeholder_for_ci,#![deny(warnings)],' src/lib.rs macros/src/lib.rs
 
+      - name: Add Rust component clippy
+        run: rustup component add clippy
+
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,22 +21,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt
-
       - name: Fail on warnings
         run: sed -i 's,//deny_warnings_placeholder_for_ci,#![deny(warnings)],' src/lib.rs macros/src/lib.rs
 
+      - name: Add Rust component
+        run: rustup component add rustfmt
+
       - name: cargo fmt --check
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run:  cargo fmt --all -- --check
 
   # Compilation check
   check:
@@ -54,12 +46,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Rust ${{ matrix.toolchain }} with target (${{ matrix.target }})
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          target: ${{ matrix.target }}
-          override: true
+      - name: Install Rust ${{ matrix.toolchain }}
+        run: |
+          rustup set profile minimal
+          rustup override set ${{ matrix.toolchain }}
+
+      - name: Configure Rust target (${{ matrix.target }})
+        run: rustup target add ${{ matrix.target }}
 
       - name: Fail on warnings
         run: sed -i 's,//deny_warnings_placeholder_for_ci,#![deny(warnings)],' src/lib.rs macros/src/lib.rs
@@ -68,11 +61,7 @@ jobs:
         uses: Swatinem/rust-cache@v1
 
       - name: cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: false
-          command: check
-          args: --target=${{ matrix.target }}
+        run: cargo check --target=${{ matrix.target }}
 
   # Clippy
   clippy:
@@ -82,13 +71,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Rust stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: x86_64-unknown-linux-gnu
-          override: true
-
       - name: Fail on warnings
         run: sed -i 's,//deny_warnings_placeholder_for_ci,#![deny(warnings)],' src/lib.rs macros/src/lib.rs
 
@@ -96,10 +78,7 @@ jobs:
         uses: Swatinem/rust-cache@v1
 
       - name: cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: false
-          command: clippy
+        run: clippy
 
   # Verify all examples, checks
   checkexamples:
@@ -116,23 +95,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Rust ${{ matrix.toolchain }} with target (${{ matrix.target }})
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          target: ${{ matrix.target }}
-          override: true
-          components: llvm-tools-preview
+      - name: Install Rust ${{ matrix.toolchain }}
+        run: |
+          rustup set profile minimal
+          rustup override set ${{ matrix.toolchain }}
+
+      - name: Configure Rust target (${{ matrix.target }})
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Add Rust component llvm-tools-preview
+        run: rustup component add llvm-tools-preview
 
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v1
 
       - name: Check the examples
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: false
-          command: check
-          args: --examples --target=${{ matrix.target }}
+        run: cargo check --examples --target=${{ matrix.target }}
 
   # Verify the example output with run-pass tests
   testexamples:
@@ -149,20 +127,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Rust ${{ matrix.toolchain }} with target (${{ matrix.target }})
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          target: ${{ matrix.target }}
-          override: true
-          components: llvm-tools-preview
+      - name: Install Rust ${{ matrix.toolchain }}
+        run: |
+          rustup set profile minimal
+          rustup override set ${{ matrix.toolchain }}
+
+      - name: Configure Rust target (${{ matrix.target }})
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Add Rust component llvm-tools-preview
+        run: rustup component add llvm-tools-preview
 
       # Use precompiled binutils
       - name: cargo install cargo-binutils
-        uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-binutils
-          version: latest
+        run: cargo install cargo-binutils
 
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v1
@@ -176,8 +154,7 @@ jobs:
         run: sed -i 's,//deny_warnings_placeholder_for_ci,#![deny(warnings)],' src/lib.rs macros/src/lib.rs
 
       - name: Run-pass tests
-        run:
-          cargo xtask --target ${{ matrix.target }}
+        run: cargo xtask --target ${{ matrix.target }}
 
   # Check the correctness of macros/ crate
   checkmacros:
@@ -193,12 +170,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Rust ${{ matrix.toolchain }} with target (${{ matrix.target }})
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          target: ${{ matrix.target }}
-          override: true
+      - name: Install Rust ${{ matrix.toolchain }}
+        run: |
+          rustup set profile minimal
+          rustup override set ${{ matrix.toolchain }}
+
+      - name: Configure Rust target (${{ matrix.target }})
+        run: rustup target add ${{ matrix.target }}
 
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v1
@@ -207,11 +185,7 @@ jobs:
         run: sed -i 's,//deny_warnings_placeholder_for_ci,#![deny(warnings)],' src/lib.rs macros/src/lib.rs
 
       - name: cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: false
-          command: check
-          args: --manifest-path macros/Cargo.toml --target=${{ matrix.target }}
+        run: cargo check --manifest-path macros/Cargo.toml --target=${{ matrix.target }}
 
   # Run the  macros test-suite
   testmacros:
@@ -221,13 +195,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: x86_64-unknown-linux-gnu
-          override: true
-
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v1
 
@@ -235,11 +202,7 @@ jobs:
         run: sed -i 's,//deny_warnings_placeholder_for_ci,#![deny(warnings)],' src/lib.rs macros/src/lib.rs
 
       - name: cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: false
-          command: test
-          args: --manifest-path macros/Cargo.toml
+        run: cargo test --manifest-path macros/Cargo.toml
 
   # Run test suite
   tests:
@@ -249,24 +212,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: x86_64-unknown-linux-gnu
-          override: true
-
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v1
 
       - name: Fail on warnings
         run: sed -i 's,//deny_warnings_placeholder_for_ci,#![deny(warnings)],' src/lib.rs macros/src/lib.rs
 
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: false
-          command: test
-          args: --test tests
+      - name: Run cargo test
+        run: cargo test --test tests
 
   # Build documentation, check links
   docs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,6 @@ jobs:
       - name: Fail on warnings
         run: sed -i 's,//deny_warnings_placeholder_for_ci,#![deny(warnings)],' src/lib.rs macros/src/lib.rs
 
-      - name: Add Rust component
-        run: rustup component add rustfmt
 
       - name: cargo fmt --check
         run:  cargo fmt --all -- --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For each category, *Added*, *Changed*, *Fixed* add new entries at the top!
 
 ### Fixed
 
+- Use native GHA rustup and cargo
 - Distinguish between thumbv8m.base and thumbv8m.main for basepri usage.
 
 ### Changed


### PR DESCRIPTION
actions-rs seems abandoned: See [link](https://github.com/actions-rs/toolchain/issues/216)

As GHA bundles rustup using it directly is trivial