### PR TITLE
NVIC prio bits must be in the range 1..=255: Handled by logical2hw()

### DIFF
--- a/ui/task-priority-too-high.rs
+++ b/ui/task-priority-too-high.rs
@@ -9,7 +9,7 @@ mod app {
     struct Local {}
 
     #[init]
-    fn init(cx: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(_: init::Context) -> (Shared, Local, init::Monotonics) {
         (Shared {}, Local {}, init::Monotonics())
     }
 

--- a/ui/task-priority-too-high.stderr
+++ b/ui/task-priority-too-high.stderr
@@ -1,11 +1,3 @@
-warning: unused variable: `cx`
-  --> ui/task-priority-too-high.rs:12:13
-   |
-12 |     fn init(cx: init::Context) -> (Shared, Local, init::Monotonics) {
-   |             ^^ help: if this is intentional, prefix it with an underscore: `_cx`
-   |
-   = note: `#[warn(unused_variables)]` on by default
-
 error[E0080]: evaluation of constant value failed
  --> ui/task-priority-too-high.rs:3:1
   |


### PR DESCRIPTION
Fixes #687